### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Enable pnpm
+        run: corepack enable
+
+      - name: Install Node dependencies
+        run: pnpm install
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Start caddy
+        run: docker compose -f test_config/compose.yml up -d caddy
+
+      - name: Wait for caddy
+        run: sleep 10
+
+      - name: Build site
+        run: pnpm run build
+
+      - name: Run tests
+        run: cargo test --workspace
+
+      - name: Stop caddy
+        if: always()
+        run: docker compose -f test_config/compose.yml down

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 /*
+!/.github
 !/contents
 !/crates
-!/src
 !/public
+!/src
 !/test_config
 !/tests
 !/.gitignore


### PR DESCRIPTION
## Summary
- add a workflow that builds the site and runs tests
- unignore `.github` so workflows are tracked

## Testing
- `pnpm run build`
- `cargo test --workspace` *(fails: missing caddy root cert)*

------
https://chatgpt.com/codex/tasks/task_e_6841be3e5c8483288deed892207fff16