### PR TITLE
コメント/リアクションに関するテストを追加

### DIFF
--- a/crates/in_memory/server/src/main.rs
+++ b/crates/in_memory/server/src/main.rs
@@ -128,8 +128,20 @@ impl ArticleProvider for InMemoryServer {
         todo!()
     }
 
-    async fn get_public_comments_until(&self, _slug: &str, _until: u64) -> (ArrayVec<ArticleComment, 10>, u64) {
-        todo!()
+    async fn get_public_comments_until(&self, _slug: &str, until: u64) -> (ArrayVec<ArticleComment, 10>, u64) {
+        let comments_raw = self.comments_raw.read().await;
+        let until = (until as usize).min(comments_raw.len());
+        let start = until.saturating_sub(10);
+        let mut comments = ArrayVec::<ArticleComment, 10>::new();
+        for raw in &comments_raw[start..until] {
+            let content = String::from_utf8_lossy(raw).to_string();
+            let _ = comments.try_push(ArticleComment {
+                author_name: "unknown".to_owned(),
+                created_at: None,
+                content,
+            });
+        }
+        (comments, start as u64)
     }
 }
 

--- a/crates/in_memory/server/src/main.rs
+++ b/crates/in_memory/server/src/main.rs
@@ -361,6 +361,7 @@ async fn main() {
                 let pending = state.pending_jobs.clone();
                 async move || {
                     let len = pending.load(std::sync::atomic::Ordering::SeqCst);
+                    tracing::info!("pending jobs: {}", len);
                     Json(len)
                 }
             }),
@@ -372,6 +373,7 @@ async fn main() {
                 async move || {
                     let comments = comments.read().await;
                     let body: Vec<String> = comments.iter().map(|c| String::from_utf8_lossy(c).to_string()).collect();
+                    tracing::info!("comments: {}", body.len());
                     Json(body)
                 }
             }),

--- a/tests/src/docker/mastodon.rs
+++ b/tests/src/docker/mastodon.rs
@@ -176,4 +176,63 @@ impl MastodonClient<'_> {
             Err(format!("{response_dump}\n{}", body).into())
         }
     }
+
+    pub async fn renote(&self, note_id: &str) -> Result<serde_json::Value, Box<dyn Error>> {
+        let response = self
+            .client
+            .post(format!("{}/api/v1/statuses/{note_id}/reblog", self.base_url))
+            .bearer_auth(self.token.as_ref().unwrap())
+            .header(ACCEPT, "application/json")
+            .send()
+            .await
+            .unwrap();
+        let succeed = response.status().is_success();
+        let response_dump = format!("{response:#?}");
+        if succeed {
+            Ok(response.json().await.unwrap())
+        } else {
+            let body = response.text().await.unwrap();
+            Err(format!("{response_dump}\n{}", body).into())
+        }
+    }
+
+    pub async fn quote_renote(&self, note_id: &str, text: &str) -> Result<serde_json::Value, Box<dyn Error>> {
+        let response = self
+            .client
+            .post(format!("{}/api/v1/statuses", self.base_url))
+            .bearer_auth(self.token.as_ref().unwrap())
+            .header(ACCEPT, "application/json")
+            .json(&serde_json::json!({"status": text, "quote_id": note_id}))
+            .send()
+            .await
+            .unwrap();
+        let succeed = response.status().is_success();
+        let response_dump = format!("{response:#?}");
+        if succeed {
+            Ok(response.json().await.unwrap())
+        } else {
+            let body = response.text().await.unwrap();
+            Err(format!("{response_dump}\n{}", body).into())
+        }
+    }
+
+    pub async fn reply(&self, note_id: &str, text: &str) -> Result<serde_json::Value, Box<dyn Error>> {
+        let response = self
+            .client
+            .post(format!("{}/api/v1/statuses", self.base_url))
+            .bearer_auth(self.token.as_ref().unwrap())
+            .header(ACCEPT, "application/json")
+            .json(&serde_json::json!({"status": text, "in_reply_to_id": note_id}))
+            .send()
+            .await
+            .unwrap();
+        let succeed = response.status().is_success();
+        let response_dump = format!("{response:#?}");
+        if succeed {
+            Ok(response.json().await.unwrap())
+        } else {
+            let body = response.text().await.unwrap();
+            Err(format!("{response_dump}\n{}", body).into())
+        }
+    }
 }

--- a/tests/src/docker/mastodon.rs
+++ b/tests/src/docker/mastodon.rs
@@ -235,4 +235,23 @@ impl MastodonClient<'_> {
             Err(format!("{response_dump}\n{}", body).into())
         }
     }
+
+    pub async fn react(&self, note_id: &str) -> Result<serde_json::Value, Box<dyn Error>> {
+        let response = self
+            .client
+            .post(format!("{}/api/v1/statuses/{note_id}/favourite", self.base_url))
+            .bearer_auth(self.token.as_ref().unwrap())
+            .header(ACCEPT, "application/json")
+            .send()
+            .await
+            .unwrap();
+        let succeed = response.status().is_success();
+        let response_dump = format!("{response:#?}");
+        if succeed {
+            Ok(response.json().await.unwrap())
+        } else {
+            let body = response.text().await.unwrap();
+            Err(format!("{response_dump}\n{}", body).into())
+        }
+    }
 }

--- a/tests/src/docker/mastodon.rs
+++ b/tests/src/docker/mastodon.rs
@@ -161,7 +161,7 @@ impl MastodonClient<'_> {
     pub async fn fetch_timeline(&self) -> Result<Vec<serde_json::Value>, Box<dyn Error>> {
         let response = self
             .client
-            .get(format!("{}/api/v1/timelines/public", self.base_url))
+            .get(format!("{}/api/v1/timelines/home", self.base_url))
             .bearer_auth(self.token.as_ref().unwrap())
             .header(ACCEPT, "application/json")
             .send()

--- a/tests/src/docker/misskey.rs
+++ b/tests/src/docker/misskey.rs
@@ -204,10 +204,6 @@ impl MisskeyClient<'_> {
             .await
             .unwrap();
         let succeed = response.status().is_success();
-        if succeed {
-            Ok(())
-        } else {
-            Err(format!("{response:?}").into())
-        }
+        if succeed { Ok(()) } else { Err(format!("{response:?}").into()) }
     }
 }

--- a/tests/src/docker/misskey.rs
+++ b/tests/src/docker/misskey.rs
@@ -193,4 +193,23 @@ impl MisskeyClient<'_> {
             Err(format!("{response_dump}\n{:#?}", body).into())
         }
     }
+
+    pub async fn react(&self, note_id: &str, reaction: &str) -> Result<serde_json::Value, Box<dyn Error>> {
+        let response = self
+            .client
+            .post(format!("{}/api/notes/reactions/create", self.base_url))
+            .header("Content-Type", "application/json")
+            .body(serde_json::to_string(&serde_json::json!({"i": self.token, "noteId": note_id, "reaction": reaction})).unwrap())
+            .send()
+            .await
+            .unwrap();
+        let succeed = response.status().is_success();
+        let response_dump = format!("{response:#?}");
+        let body = response.json().await.unwrap();
+        if succeed {
+            Ok(body)
+        } else {
+            Err(format!("{response_dump}\n{:#?}", body).into())
+        }
+    }
 }

--- a/tests/src/docker/misskey.rs
+++ b/tests/src/docker/misskey.rs
@@ -194,7 +194,7 @@ impl MisskeyClient<'_> {
         }
     }
 
-    pub async fn react(&self, note_id: &str, reaction: &str) -> Result<serde_json::Value, Box<dyn Error>> {
+    pub async fn react(&self, note_id: &str, reaction: &str) -> Result<(), Box<dyn Error>> {
         let response = self
             .client
             .post(format!("{}/api/notes/reactions/create", self.base_url))
@@ -204,12 +204,10 @@ impl MisskeyClient<'_> {
             .await
             .unwrap();
         let succeed = response.status().is_success();
-        let response_dump = format!("{response:#?}");
-        let body = response.json().await.unwrap();
         if succeed {
-            Ok(body)
+            Ok(())
         } else {
-            Err(format!("{response_dump}\n{:#?}", body).into())
+            Err(format!("{response:?}").into())
         }
     }
 }

--- a/tests/src/docker/misskey.rs
+++ b/tests/src/docker/misskey.rs
@@ -136,4 +136,61 @@ impl MisskeyClient<'_> {
             Err(format!("{response_dump}\n{:#?}", body).into())
         }
     }
+
+    pub async fn renote(&self, note_id: &str) -> Result<serde_json::Value, Box<dyn Error>> {
+        let response = self
+            .client
+            .post(format!("{}/api/notes/create", self.base_url))
+            .header("Content-Type", "application/json")
+            .body(serde_json::to_string(&serde_json::json!({"i": self.token, "renoteId": note_id})).unwrap())
+            .send()
+            .await
+            .unwrap();
+        let succeed = response.status().is_success();
+        let response_dump = format!("{response:#?}");
+        let body = response.json().await.unwrap();
+        if succeed {
+            Ok(body)
+        } else {
+            Err(format!("{response_dump}\n{:#?}", body).into())
+        }
+    }
+
+    pub async fn quote_renote(&self, note_id: &str, text: &str) -> Result<serde_json::Value, Box<dyn Error>> {
+        let response = self
+            .client
+            .post(format!("{}/api/notes/create", self.base_url))
+            .header("Content-Type", "application/json")
+            .body(serde_json::to_string(&serde_json::json!({"i": self.token, "renoteId": note_id, "text": text})).unwrap())
+            .send()
+            .await
+            .unwrap();
+        let succeed = response.status().is_success();
+        let response_dump = format!("{response:#?}");
+        let body = response.json().await.unwrap();
+        if succeed {
+            Ok(body)
+        } else {
+            Err(format!("{response_dump}\n{:#?}", body).into())
+        }
+    }
+
+    pub async fn reply(&self, note_id: &str, text: &str) -> Result<serde_json::Value, Box<dyn Error>> {
+        let response = self
+            .client
+            .post(format!("{}/api/notes/create", self.base_url))
+            .header("Content-Type", "application/json")
+            .body(serde_json::to_string(&serde_json::json!({"i": self.token, "replyId": note_id, "text": text})).unwrap())
+            .send()
+            .await
+            .unwrap();
+        let succeed = response.status().is_success();
+        let response_dump = format!("{response:#?}");
+        let body = response.json().await.unwrap();
+        if succeed {
+            Ok(body)
+        } else {
+            Err(format!("{response_dump}\n{:#?}", body).into())
+        }
+    }
 }

--- a/tests/src/docker/sharkey.rs
+++ b/tests/src/docker/sharkey.rs
@@ -193,4 +193,23 @@ impl SharkeyClient<'_> {
             Err(format!("{response_dump}\n{:#?}", body).into())
         }
     }
+
+    pub async fn react(&self, note_id: &str, reaction: &str) -> Result<serde_json::Value, Box<dyn Error>> {
+        let response = self
+            .client
+            .post(format!("{}/api/notes/reactions/create", self.base_url))
+            .header("Content-Type", "application/json")
+            .body(serde_json::to_string(&serde_json::json!({"i": self.token, "noteId": note_id, "reaction": reaction})).unwrap())
+            .send()
+            .await
+            .unwrap();
+        let succeed = response.status().is_success();
+        let response_dump = format!("{response:#?}");
+        let body = response.json().await.unwrap();
+        if succeed {
+            Ok(body)
+        } else {
+            Err(format!("{response_dump}\n{:#?}", body).into())
+        }
+    }
 }

--- a/tests/src/docker/sharkey.rs
+++ b/tests/src/docker/sharkey.rs
@@ -136,4 +136,61 @@ impl SharkeyClient<'_> {
             Err(format!("{response_dump}\n{:#?}", body).into())
         }
     }
+
+    pub async fn renote(&self, note_id: &str) -> Result<serde_json::Value, Box<dyn Error>> {
+        let response = self
+            .client
+            .post(format!("{}/api/notes/create", self.base_url))
+            .header("Content-Type", "application/json")
+            .body(serde_json::to_string(&serde_json::json!({"i": self.token, "renoteId": note_id})).unwrap())
+            .send()
+            .await
+            .unwrap();
+        let succeed = response.status().is_success();
+        let response_dump = format!("{response:#?}");
+        let body = response.json().await.unwrap();
+        if succeed {
+            Ok(body)
+        } else {
+            Err(format!("{response_dump}\n{:#?}", body).into())
+        }
+    }
+
+    pub async fn quote_renote(&self, note_id: &str, text: &str) -> Result<serde_json::Value, Box<dyn Error>> {
+        let response = self
+            .client
+            .post(format!("{}/api/notes/create", self.base_url))
+            .header("Content-Type", "application/json")
+            .body(serde_json::to_string(&serde_json::json!({"i": self.token, "renoteId": note_id, "text": text})).unwrap())
+            .send()
+            .await
+            .unwrap();
+        let succeed = response.status().is_success();
+        let response_dump = format!("{response:#?}");
+        let body = response.json().await.unwrap();
+        if succeed {
+            Ok(body)
+        } else {
+            Err(format!("{response_dump}\n{:#?}", body).into())
+        }
+    }
+
+    pub async fn reply(&self, note_id: &str, text: &str) -> Result<serde_json::Value, Box<dyn Error>> {
+        let response = self
+            .client
+            .post(format!("{}/api/notes/create", self.base_url))
+            .header("Content-Type", "application/json")
+            .body(serde_json::to_string(&serde_json::json!({"i": self.token, "replyId": note_id, "text": text})).unwrap())
+            .send()
+            .await
+            .unwrap();
+        let succeed = response.status().is_success();
+        let response_dump = format!("{response:#?}");
+        let body = response.json().await.unwrap();
+        if succeed {
+            Ok(body)
+        } else {
+            Err(format!("{response_dump}\n{:#?}", body).into())
+        }
+    }
 }

--- a/tests/src/docker/sharkey.rs
+++ b/tests/src/docker/sharkey.rs
@@ -194,7 +194,7 @@ impl SharkeyClient<'_> {
         }
     }
 
-    pub async fn react(&self, note_id: &str, reaction: &str) -> Result<serde_json::Value, Box<dyn Error>> {
+    pub async fn react(&self, note_id: &str, reaction: &str) -> Result<(), Box<dyn Error>> {
         let response = self
             .client
             .post(format!("{}/api/notes/reactions/create", self.base_url))
@@ -204,12 +204,10 @@ impl SharkeyClient<'_> {
             .await
             .unwrap();
         let succeed = response.status().is_success();
-        let response_dump = format!("{response:#?}");
-        let body = response.json().await.unwrap();
         if succeed {
-            Ok(body)
+            Ok(())
         } else {
-            Err(format!("{response_dump}\n{:#?}", body).into())
+            Err(format!("{response:?}").into())
         }
     }
 }

--- a/tests/src/docker/sharkey.rs
+++ b/tests/src/docker/sharkey.rs
@@ -204,10 +204,6 @@ impl SharkeyClient<'_> {
             .await
             .unwrap();
         let succeed = response.status().is_success();
-        if succeed {
-            Ok(())
-        } else {
-            Err(format!("{response:?}").into())
-        }
+        if succeed { Ok(()) } else { Err(format!("{response:?}").into()) }
     }
 }

--- a/tests/src/in_memory.rs
+++ b/tests/src/in_memory.rs
@@ -1,6 +1,5 @@
 use fblog_system_core::traits::QueueData;
 use reqwest::Client;
-use serde_json::Value;
 use std::path::Path;
 use std::process::Child;
 use std::time::Duration;

--- a/tests/src/in_memory.rs
+++ b/tests/src/in_memory.rs
@@ -60,14 +60,25 @@ impl InMemoryBlog {
         self.client.delete(format!("http://localhost:8787/articles/{slug}")).send().await.unwrap();
     }
 
-    pub async fn get_article_comments(&self, slug: &str) -> serde_json::Value {
+    pub async fn get_comments_raw(&self) -> serde_json::Value {
         self.client
-            .get(format!("http://localhost:8787/articles/{slug}?data=comments"))
+            .get("http://localhost:8787/comments_raw")
             .header("Accept", "application/json")
             .send()
             .await
             .unwrap()
             .json::<serde_json::Value>()
+            .await
+            .unwrap()
+    }
+
+    pub async fn job_queue_len(&self) -> usize {
+        self.client
+            .get("http://localhost:8787/job_queue_len")
+            .send()
+            .await
+            .unwrap()
+            .json::<usize>()
             .await
             .unwrap()
     }

--- a/tests/src/in_memory.rs
+++ b/tests/src/in_memory.rs
@@ -1,5 +1,6 @@
 use fblog_system_core::traits::QueueData;
 use reqwest::Client;
+use serde_json::Value;
 use std::path::Path;
 use std::process::Child;
 use std::time::Duration;
@@ -57,6 +58,18 @@ impl InMemoryBlog {
 
     pub async fn delete_article(&self, slug: &str) {
         self.client.delete(format!("http://localhost:8787/articles/{slug}")).send().await.unwrap();
+    }
+
+    pub async fn get_article_comments(&self, slug: &str) -> serde_json::Value {
+        self.client
+            .get(format!("http://localhost:8787/articles/{slug}?data=comments"))
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .unwrap()
+            .json::<serde_json::Value>()
+            .await
+            .unwrap()
     }
 }
 

--- a/tests/tests/e2e_test.rs
+++ b/tests/tests/e2e_test.rs
@@ -79,6 +79,38 @@ fn main() {
             async { assert_eq!(dbg!(mastodon.fetch_timeline().await.unwrap()).len(), 2) },
         );
 
+        tokio::try_join!(
+            sharkey.renote(sharkey_note["object"]["id"].as_str().unwrap()),
+            misskey.renote(misskey_note["object"]["id"].as_str().unwrap()),
+            mastodon.renote(mastodon_note["id"].as_str().unwrap()),
+        )
+        .unwrap();
+
+        tokio::try_join!(
+            sharkey.quote_renote(sharkey_note["object"]["id"].as_str().unwrap(), "quote"),
+            misskey.quote_renote(misskey_note["object"]["id"].as_str().unwrap(), "quote"),
+            mastodon.quote_renote(mastodon_note["id"].as_str().unwrap(), "quote"),
+        )
+        .unwrap();
+
+        tokio::try_join!(
+            sharkey.reply(sharkey_note["object"]["id"].as_str().unwrap(), "reply"),
+            misskey.reply(misskey_note["object"]["id"].as_str().unwrap(), "reply"),
+            mastodon.reply(mastodon_note["id"].as_str().unwrap(), "reply"),
+        )
+        .unwrap();
+
+        wait_for(async || {
+            in_memory
+                .get_article_comments("first-post")
+                .await["comments"]
+                .as_array()
+                .unwrap()
+                .len()
+                >= 9
+        })
+        .await;
+
         in_memory
             .send_queue_data(QueueData::DeliveryNewArticleToAll {
                 slug: "markdown-style-guide".to_owned(),
@@ -86,9 +118,9 @@ fn main() {
             .await;
 
         tokio::join!(
-            wait_for(async || sharkey.fetch_timeline().await.unwrap().len() == 3),
-            wait_for(async || misskey.fetch_timeline().await.unwrap().len() == 3),
-            wait_for(async || mastodon.fetch_timeline().await.unwrap().len() == 3),
+            wait_for(async || sharkey.fetch_timeline().await.unwrap().len() == 6),
+            wait_for(async || misskey.fetch_timeline().await.unwrap().len() == 6),
+            wait_for(async || mastodon.fetch_timeline().await.unwrap().len() == 6),
         );
 
         let mut new_article_ap = serde_json::from_str::<serde_json::Value>(include_str!("../../dist/raw__/articles/ap/markdown-style-guide.json")).unwrap();
@@ -120,9 +152,9 @@ fn main() {
             .await;
 
         tokio::join!(
-            wait_for(async || sharkey.fetch_timeline().await.unwrap().len() == 2),
-            wait_for(async || misskey.fetch_timeline().await.unwrap().len() == 2),
-            wait_for(async || mastodon.fetch_timeline().await.unwrap().len() == 2),
+            wait_for(async || sharkey.fetch_timeline().await.unwrap().len() == 5),
+            wait_for(async || misskey.fetch_timeline().await.unwrap().len() == 5),
+            wait_for(async || mastodon.fetch_timeline().await.unwrap().len() == 5),
         );
 
         tokio::try_join!(
@@ -141,9 +173,9 @@ fn main() {
         tokio::time::sleep(Duration::from_secs(10)).await;
 
         tokio::join!(
-            async { assert_eq!(sharkey.fetch_timeline().await.unwrap().len(), 2) },
-            async { assert_eq!(misskey.fetch_timeline().await.unwrap().len(), 2) },
-            async { assert_eq!(mastodon.fetch_timeline().await.unwrap().len(), 2) },
+            async { assert_eq!(sharkey.fetch_timeline().await.unwrap().len(), 5) },
+            async { assert_eq!(misskey.fetch_timeline().await.unwrap().len(), 5) },
+            async { assert_eq!(mastodon.fetch_timeline().await.unwrap().len(), 5) },
         );
     });
 }

--- a/tests/tests/e2e_test.rs
+++ b/tests/tests/e2e_test.rs
@@ -162,6 +162,8 @@ fn main() {
         )
         .unwrap();
 
+        wait_for(async || in_memory.job_queue_len().await == 0).await;
+
         in_memory
             .send_queue_data(QueueData::DeliveryNewArticleToAll {
                 slug: "second-post".to_owned(),

--- a/tests/tests/e2e_test.rs
+++ b/tests/tests/e2e_test.rs
@@ -101,6 +101,7 @@ fn main() {
         .unwrap();
 
         wait_for(async || in_memory.get_comments_raw().await.as_array().unwrap().len() >= 9).await;
+        assert_eq!(in_memory.get_comments_raw().await.as_array().unwrap().len(), 9);
 
         in_memory
             .send_queue_data(QueueData::DeliveryNewArticleToAll {

--- a/tests/tests/e2e_test.rs
+++ b/tests/tests/e2e_test.rs
@@ -107,8 +107,8 @@ fn main() {
         )
         .unwrap();
 
-        wait_for(async || in_memory.get_comments_raw().await.as_array().unwrap().len() >= 9).await;
-        assert_eq!(in_memory.get_comments_raw().await.as_array().unwrap().len(), 9);
+        wait_for(async || in_memory.get_comments_raw().await.as_array().unwrap().len() >= 6).await;
+        assert_eq!(in_memory.get_comments_raw().await.as_array().unwrap().len(), 6);
 
         in_memory
             .send_queue_data(QueueData::DeliveryNewArticleToAll {

--- a/tests/tests/e2e_test.rs
+++ b/tests/tests/e2e_test.rs
@@ -100,8 +100,15 @@ fn main() {
         )
         .unwrap();
 
-        wait_for(async || in_memory.get_comments_raw().await.as_array().unwrap().len() >= 6).await;
-        assert_eq!(in_memory.get_comments_raw().await.as_array().unwrap().len(), 6);
+        tokio::try_join!(
+            sharkey.react(sharkey_note["object"]["id"].as_str().unwrap(), "like"),
+            misskey.react(misskey_note["object"]["id"].as_str().unwrap(), "like"),
+            mastodon.react(mastodon_note["id"].as_str().unwrap()),
+        )
+        .unwrap();
+
+        wait_for(async || in_memory.get_comments_raw().await.as_array().unwrap().len() >= 9).await;
+        assert_eq!(in_memory.get_comments_raw().await.as_array().unwrap().len(), 9);
 
         in_memory
             .send_queue_data(QueueData::DeliveryNewArticleToAll {

--- a/tests/tests/e2e_test.rs
+++ b/tests/tests/e2e_test.rs
@@ -100,8 +100,8 @@ fn main() {
         )
         .unwrap();
 
-        wait_for(async || in_memory.get_comments_raw().await.as_array().unwrap().len() >= 9).await;
-        assert_eq!(in_memory.get_comments_raw().await.as_array().unwrap().len(), 9);
+        wait_for(async || in_memory.get_comments_raw().await.as_array().unwrap().len() >= 6).await;
+        assert_eq!(in_memory.get_comments_raw().await.as_array().unwrap().len(), 6);
 
         in_memory
             .send_queue_data(QueueData::DeliveryNewArticleToAll {

--- a/tests/tests/e2e_test.rs
+++ b/tests/tests/e2e_test.rs
@@ -100,22 +100,15 @@ fn main() {
         )
         .unwrap();
 
-        wait_for(async || {
-            in_memory
-                .get_article_comments("first-post")
-                .await["comments"]
-                .as_array()
-                .unwrap()
-                .len()
-                >= 9
-        })
-        .await;
+        wait_for(async || in_memory.get_comments_raw().await.as_array().unwrap().len() >= 9).await;
 
         in_memory
             .send_queue_data(QueueData::DeliveryNewArticleToAll {
                 slug: "markdown-style-guide".to_owned(),
             })
             .await;
+
+        wait_for(async || in_memory.job_queue_len().await == 0).await;
 
         tokio::join!(
             wait_for(async || sharkey.fetch_timeline().await.unwrap().len() == 6),
@@ -135,6 +128,8 @@ fn main() {
             })
             .await;
 
+        wait_for(async || in_memory.job_queue_len().await == 0).await;
+
         tokio::time::sleep(Duration::from_secs(10)).await;
 
         tokio::join!(
@@ -150,6 +145,8 @@ fn main() {
                 author: "default".to_owned(),
             })
             .await;
+
+        wait_for(async || in_memory.job_queue_len().await == 0).await;
 
         tokio::join!(
             wait_for(async || sharkey.fetch_timeline().await.unwrap().len() == 5),
@@ -169,6 +166,8 @@ fn main() {
                 slug: "second-post".to_owned(),
             })
             .await;
+
+        wait_for(async || in_memory.job_queue_len().await == 0).await;
 
         tokio::time::sleep(Duration::from_secs(10)).await;
 

--- a/tests/tests/e2e_test.rs
+++ b/tests/tests/e2e_test.rs
@@ -101,8 +101,8 @@ fn main() {
         .unwrap();
 
         tokio::try_join!(
-            sharkey.react(sharkey_note["object"]["id"].as_str().unwrap(), "like"),
-            misskey.react(misskey_note["object"]["id"].as_str().unwrap(), "like"),
+            sharkey.react(sharkey_note["object"]["id"].as_str().unwrap(), "👍"),
+            misskey.react(misskey_note["object"]["id"].as_str().unwrap(), "👍"),
             mastodon.react(mastodon_note["id"].as_str().unwrap()),
         )
         .unwrap();


### PR DESCRIPTION
## Summary
- update the wait_for call in e2e test
- adjust expected timeline lengths after comment operations

## Testing
- `cargo test --quiet` *(fails: couldn't read certificate and article files)*

------
https://chatgpt.com/codex/tasks/task_e_684721e7ecc883289ecd22b92e5c8ab0