### PR TITLE
Simplify follower batching API

### DIFF
--- a/crates/cloudflare_workers/src/lib.rs
+++ b/crates/cloudflare_workers/src/lib.rs
@@ -7,8 +7,8 @@ use chrono::Utc;
 use fblog_system_core::process_queue::{ProcessQueueResult, process_queue};
 use fblog_system_core::route::router;
 use fblog_system_core::traits::*;
-use futures::stream::TryStreamExt;
 use futures::Stream;
+use futures::stream::TryStreamExt;
 use http::StatusCode;
 use http_body_util::{BodyDataStream, BodyExt};
 use rsa::pkcs8::DecodePrivateKey;
@@ -445,7 +445,6 @@ impl UserProvider for WorkerState {
             }
         }
     }
-
 
     #[worker::send]
     async fn get_followers_inbox_batch(&self, username: &str, last_inbox: &str) -> (ArrayVec<String, 10>, String) {

--- a/crates/cloudflare_workers/src/lib.rs
+++ b/crates/cloudflare_workers/src/lib.rs
@@ -8,7 +8,7 @@ use fblog_system_core::process_queue::{ProcessQueueResult, process_queue};
 use fblog_system_core::route::router;
 use fblog_system_core::traits::*;
 use futures::stream::TryStreamExt;
-use futures::{Future, Stream};
+use futures::Stream;
 use http::StatusCode;
 use http_body_util::{BodyDataStream, BodyExt};
 use rsa::pkcs8::DecodePrivateKey;
@@ -446,27 +446,38 @@ impl UserProvider for WorkerState {
         }
     }
 
-    #[allow(refining_impl_trait)]
-    fn get_followers_inbox(&self, username: &str) -> impl Future<Output = impl Stream<Item = String> + Send> + Send {
-        let username = username.to_owned();
-        let db = self.db.as_ref();
-        worker::send::SendFuture::new(async move {
-            let rows: Vec<Vec<String>> = match worker::query!(db, "SELECT DISTINCT inbox FROM followers WHERE username = ?1", &username) {
-                Ok(stmt) => match stmt.raw().await {
-                    Ok(r) => r,
-                    Err(e) => {
-                        tracing::error!(error = ?e, "failed to execute get_followers_inbox");
-                        Vec::new()
-                    }
-                },
-                Err(e) => {
-                    tracing::error!(error = ?e, "failed to prepare get_followers_inbox");
-                    Vec::new()
+
+    #[worker::send]
+    async fn get_followers_inbox_batch(&self, username: &str, last_inbox: &str) -> (ArrayVec<String, 10>, String) {
+        let stmt = match worker::query!(
+            self.db.as_ref(),
+            "SELECT DISTINCT inbox FROM followers WHERE username = ?1 AND inbox > ?2 ORDER BY inbox LIMIT 10",
+            &username,
+            &last_inbox
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!(error = ?e, "failed to prepare get_followers_inbox_batch");
+                return (ArrayVec::new(), last_inbox.to_string());
+            }
+        };
+        let rows: Vec<Vec<String>> = match stmt.raw().await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!(error = ?e, "failed to execute get_followers_inbox_batch");
+                return (ArrayVec::new(), last_inbox.to_string());
+            }
+        };
+        let mut vec = ArrayVec::<String, 10>::new();
+        for mut row in rows {
+            if let Some(inbox) = row.pop() {
+                if vec.try_push(inbox).is_err() {
+                    break;
                 }
-            };
-            let iter = rows.into_iter().filter_map(|mut r| r.pop());
-            futures::stream::iter(iter)
-        })
+            }
+        }
+        let next_last = vec.last().cloned().unwrap_or_default();
+        (vec, next_last)
     }
 }
 impl Queue for WorkerState {

--- a/crates/core/src/process_queue.rs
+++ b/crates/core/src/process_queue.rs
@@ -285,7 +285,15 @@ where
         }
         QueueData::DeliveryNewArticleBatch { slug, author, last_inbox } => {
             let (inboxes, next_last) = state.get_followers_inbox_batch(&author, &last_inbox).await;
-            let is_full = inboxes.is_full();
+            if inboxes.is_full() {
+                state
+                    .enqueue(QueueData::DeliveryNewArticleBatch {
+                        slug: slug.clone(),
+                        author: author.clone(),
+                        last_inbox: next_last,
+                    })
+                    .await;
+            }
             for inbox in inboxes.into_iter() {
                 state
                     .enqueue(QueueData::DeliveryNewArticle {
@@ -295,20 +303,19 @@ where
                     })
                     .await;
             }
-            if is_full {
-                state
-                    .enqueue(QueueData::DeliveryNewArticleBatch {
-                        slug,
-                        author,
-                        last_inbox: next_last,
-                    })
-                    .await;
-            }
             return ProcessQueueResult::Finished;
         }
         QueueData::DeliveryUpdateArticleBatch { slug, author, last_inbox } => {
             let (inboxes, next_last) = state.get_followers_inbox_batch(&author, &last_inbox).await;
-            let is_full = inboxes.is_full();
+            if inboxes.is_full() {
+                state
+                    .enqueue(QueueData::DeliveryUpdateArticleBatch {
+                        slug: slug.clone(),
+                        author: author.clone(),
+                        last_inbox: next_last,
+                    })
+                    .await;
+            }
             for inbox in inboxes.into_iter() {
                 state
                     .enqueue(QueueData::DeliveryUpdateArticle {
@@ -318,35 +325,25 @@ where
                     })
                     .await;
             }
-            if is_full {
-                state
-                    .enqueue(QueueData::DeliveryUpdateArticleBatch {
-                        slug,
-                        author,
-                        last_inbox: next_last,
-                    })
-                    .await;
-            }
             return ProcessQueueResult::Finished;
         }
         QueueData::DeliveryDeleteArticleBatch { slug, author, last_inbox } => {
             let (inboxes, next_last) = state.get_followers_inbox_batch(&author, &last_inbox).await;
-            let is_full = inboxes.is_full();
+            if inboxes.is_full() {
+                state
+                    .enqueue(QueueData::DeliveryDeleteArticleBatch {
+                        slug: slug.clone(),
+                        author: author.clone(),
+                        last_inbox: next_last,
+                    })
+                    .await;
+            }
             for inbox in inboxes.into_iter() {
                 state
                     .enqueue(QueueData::DeliveryDeleteArticle {
                         slug: slug.clone(),
                         author: author.clone(),
                         inbox,
-                    })
-                    .await;
-            }
-            if is_full {
-                state
-                    .enqueue(QueueData::DeliveryDeleteArticleBatch {
-                        slug,
-                        author,
-                        last_inbox: next_last,
                     })
                     .await;
             }

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -60,11 +60,7 @@ pub trait UserProvider {
     fn add_follower(&self, username: &str, follower_id: &str, inbox: &str, event_id: &str) -> impl Future<Output = ()> + Send;
     fn remove_follower(&self, username: &str, event_id: &str) -> impl Future<Output = ()> + Send;
     fn remove_follower_by_actor(&self, username: &str, actor: &str) -> impl Future<Output = ()> + Send;
-    fn get_followers_inbox_batch(
-        &self,
-        username: &str,
-        last_inbox: &str,
-    ) -> impl Future<Output = (ArrayVec<String, 10>, String)> + Send;
+    fn get_followers_inbox_batch(&self, username: &str, last_inbox: &str) -> impl Future<Output = (ArrayVec<String, 10>, String)> + Send;
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -3,7 +3,6 @@ use axum::body::Body;
 use axum::http::Request;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
-use futures::Stream;
 use rsa::pkcs1v15::SigningKey;
 use serde::{Deserialize, Serialize};
 use std::error::Error;
@@ -61,7 +60,11 @@ pub trait UserProvider {
     fn add_follower(&self, username: &str, follower_id: &str, inbox: &str, event_id: &str) -> impl Future<Output = ()> + Send;
     fn remove_follower(&self, username: &str, event_id: &str) -> impl Future<Output = ()> + Send;
     fn remove_follower_by_actor(&self, username: &str, actor: &str) -> impl Future<Output = ()> + Send;
-    fn get_followers_inbox(&self, username: &str) -> impl Future<Output: Stream<Item = String> + Send> + Send;
+    fn get_followers_inbox_batch(
+        &self,
+        username: &str,
+        last_inbox: &str,
+    ) -> impl Future<Output = (ArrayVec<String, 10>, String)> + Send;
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -82,6 +85,21 @@ pub enum QueueData {
     DeliveryDeleteArticleToAll {
         slug: String,
         author: String,
+    },
+    DeliveryNewArticleBatch {
+        slug: String,
+        author: String,
+        last_inbox: String,
+    },
+    DeliveryUpdateArticleBatch {
+        slug: String,
+        author: String,
+        last_inbox: String,
+    },
+    DeliveryDeleteArticleBatch {
+        slug: String,
+        author: String,
+        last_inbox: String,
     },
     DeliveryNewArticle {
         slug: String,


### PR DESCRIPTION
## Summary
- drop unused `get_followers_inbox` API and related imports
- keep only `get_followers_inbox_batch` for pagination

## Testing
- `cargo check --quiet`
- `cargo test --workspace --exclude e2e_test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6858130bf14483288fbdd811b1de8c1a