### PR TITLE
Add hero image to ActivityPub article data

### DIFF
--- a/src/pages/raw__/articles/ap/[...slug].json.ts
+++ b/src/pages/raw__/articles/ap/[...slug].json.ts
@@ -52,6 +52,12 @@ export async function GET({params, props, request}) {
 
     // Extract image references from the collected data
     const attachments = [];
+    if (article.data.heroImage) {
+        attachments.push({
+            type: "Image",
+            url: article.data.heroImage.startsWith('http') ? article.data.heroImage : `${baseUrl}${article.data.heroImage}`,
+        });
+    }
     if (vFile.data.images && Array.isArray(vFile.data.images)) {
         for (const image of vFile.data.images) {
             attachments.push({


### PR DESCRIPTION
## Summary
- include hero image in the ActivityPub endpoint for articles

## Testing
- `cargo test --quiet` *(fails: couldn't read cert files)*
- `npx tsc -p tsconfig.json` *(fails: missing node modules)*

------
https://chatgpt.com/codex/tasks/task_e_685a846abdfc8328a7b1b35b8c481409