### PR TITLE
Fix slug handling

### DIFF
--- a/crates/core/src/process_queue.rs
+++ b/crates/core/src/process_queue.rs
@@ -69,7 +69,7 @@ where
                 } => {
                     let reply_target = reply_target.into_string();
                     let slug = match reply_target.strip_prefix(&format!("{}/articles/", state.url())) {
-                        Some(slug) => slug,
+                        Some(slug) => slug.trim_matches('/'),
                         None => {
                             tracing::warn!("invalid reply target: {reply_target}");
                             return ProcessQueueResult::Finished;
@@ -93,7 +93,7 @@ where
                 }
                 ResponseBody::Like { id, actor, object, content } => {
                     let slug = match object.strip_prefix(&format!("{}/articles/", state.url())) {
-                        Some(slug) => slug,
+                        Some(slug) => slug.trim_matches('/'),
                         None => {
                             tracing::warn!("invalid reaction target: {object}");
                             return ProcessQueueResult::Finished;
@@ -209,7 +209,7 @@ where
                             tracing::info!(undo_actor, actor, "actor mismatch");
                             return ProcessQueueResult::Finished;
                         }
-                        let Some(slug) = object.strip_prefix(&format!("{}/articles/", state.url())) else {
+                        let Some(slug) = object.strip_prefix(&format!("{}/articles/", state.url())).map(|s| s.trim_matches('/')) else {
                             tracing::warn!(object, "invalid reaction target");
                             return ProcessQueueResult::Finished;
                         };

--- a/crates/core/src/route/articles.rs
+++ b/crates/core/src/route/articles.rs
@@ -104,6 +104,7 @@ pub async fn article_or_comments_get<E>(
 where
     E: Env + ArticleProvider + Clone,
 {
+    let slug = slug.trim_matches('/').to_string();
     match query.data {
         None => article_get(header, slug, state).await,
         Some(ArticleData::Meta) => article_metadata_get(header, slug, state).await,

--- a/crates/core/src/route/articles/events.rs
+++ b/crates/core/src/route/articles/events.rs
@@ -13,15 +13,16 @@ where
     E: Env + ArticleProvider,
 {
     let header = HeaderReader::new(&header);
+    let slug = slug.trim_matches('/');
     let Some(AcceptMime::AP) = header.select(AcceptMimeSet::AP) else {
         return StatusCode::NOT_ACCEPTABLE.into_response();
     };
-    if !state.exists_article(&slug).await {
+    if !state.exists_article(slug).await {
         return StatusCode::NOT_FOUND.into_response();
     }
 
     let url = state.url();
-    let author = state.get_author_id(&slug).await.unwrap();
+    let author = state.get_author_id(slug).await.unwrap();
     let actor = serde_json::to_string(&format!("{url}/users/{author}")).unwrap();
     let id = serde_json::to_string(&format!("{url}/events/articles/create/{slug}")).unwrap();
     let object = serde_json::to_string(&format!("{url}/articles/{slug}")).unwrap();
@@ -45,15 +46,16 @@ where
     E: Env + ArticleProvider,
 {
     let header = HeaderReader::new(&header);
+    let slug = slug.trim_matches('/');
     let Some(AcceptMime::AP) = header.select(AcceptMimeSet::AP) else {
         return StatusCode::NOT_ACCEPTABLE.into_response();
     };
-    if !state.exists_article(&slug).await {
+    if !state.exists_article(slug).await {
         return StatusCode::NOT_FOUND.into_response();
     }
 
     let url = state.url();
-    let author = state.get_author_id(&slug).await.unwrap();
+    let author = state.get_author_id(slug).await.unwrap();
     let actor = serde_json::to_string(&format!("{url}/users/{author}")).unwrap();
     let id = serde_json::to_string(&format!("{url}/events/articles/update/{slug}")).unwrap();
     let object = serde_json::to_string(&format!("{url}/articles/{slug}")).unwrap();
@@ -77,15 +79,16 @@ where
     E: Env + ArticleProvider,
 {
     let header = HeaderReader::new(&header);
+    let slug = slug.trim_matches('/');
     let Some(AcceptMime::AP) = header.select(AcceptMimeSet::AP) else {
         return StatusCode::NOT_ACCEPTABLE.into_response();
     };
-    if state.exists_article(&slug).await {
+    if state.exists_article(slug).await {
         return StatusCode::NOT_FOUND.into_response();
     }
 
     let url = state.url();
-    let author = state.get_author_id(&slug).await.unwrap();
+    let author = state.get_author_id(slug).await.unwrap();
     let actor = serde_json::to_string(&format!("{url}/users/{author}")).unwrap();
     let id = serde_json::to_string(&format!("{url}/events/articles/delete/{slug}")).unwrap();
     let object = serde_json::to_string(&format!("{url}/articles/{slug}")).unwrap();

--- a/crates/in_memory/server/src/main.rs
+++ b/crates/in_memory/server/src/main.rs
@@ -314,8 +314,9 @@ async fn main() {
                     slug: String,
                 }
                 async move |Query(ReplaceArticleQuery { slug }), body: String| {
+                    let slug = slug.trim_matches('/');
                     let mut articles = state.articles.write().await;
-                    articles.get_mut(&slug).unwrap().info_ap = body;
+                    articles.get_mut(slug).unwrap().info_ap = body;
                 }
             }),
         )
@@ -324,8 +325,9 @@ async fn main() {
             delete({
                 let state = state.clone();
                 async move |Path(slug): Path<String>| {
+                    let slug = slug.trim_matches('/');
                     let mut articles = state.articles.write().await;
-                    articles.remove(&slug);
+                    articles.remove(slug);
                 }
             }),
         )

--- a/src/pages/raw__/articles/ap/[...slug].json.ts
+++ b/src/pages/raw__/articles/ap/[...slug].json.ts
@@ -13,7 +13,7 @@ export async function getStaticPaths() {
 
     return articles.map(article => {
         // Use the path without the extension as the slug
-        const slug = article.id.replace(/\.md$/, '');
+        const slug = article.id.replace(/\.md$/, '').replace(/^\/+|\/+$/g, "");
 
         return {
             params: {slug},
@@ -25,7 +25,7 @@ export async function getStaticPaths() {
 export const prerender = true;
 
 export async function GET({params, props, request}) {
-    const {slug} = params;
+    const slug = params.slug.replace(/^\/+|\/+$/g, "");
     const {article} = props;
     const url = new URL(request.url);
     const baseUrl = `${url.protocol}//${url.host}`;

--- a/src/pages/raw__/articles/author/[...slug].ts
+++ b/src/pages/raw__/articles/author/[...slug].ts
@@ -3,7 +3,7 @@ import { getCollection } from 'astro:content';
 export async function getStaticPaths() {
     const articles = await getCollection('articles');
     return articles.map(article => {
-        const slug = article.id.replace(/\.md$/, '');
+        const slug = article.id.replace(/\.md$/, '').replace(/^\/+|\/+$/g, "");
         return { params: { slug }, props: { article } };
     });
 }


### PR DESCRIPTION
## Summary
- sanitize slugs across handlers and events by trimming leading and trailing slashes
- adjust in-memory server routes to trim slug
- strip slashes in Astro pages when generating slugs

## Testing
- `cargo test` *(fails: couldn't read root cert and markdown files)*
- `pnpm exec biome format --write src/pages/raw__/articles/ap/[...slug].json.ts src/pages/raw__/articles/author/[...slug].ts` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685c259d7de08328bdb786d5659e9cfe