### PR TITLE
[codex] Add dist VRT workflows

### DIFF
--- a/.github/scripts/capture_sample_build_vrt_data.sh
+++ b/.github/scripts/capture_sample_build_vrt_data.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+rm -rf contents public dist
+
+mkdir -p contents/articles contents/users public
+cp -R test_config/test_data/e2e_test/contents/articles/. contents/articles/
+cp -R test_config/test_data/e2e_test/contents/users/. contents/users/
+cp -R test_config/test_data/e2e_test/public/. public/
+
+PUBLIC_KEY_FILE="test_config/public-key-for-test.pem" SITE_URL="https://blog.test" pnpm run build

--- a/.github/workflows/sample_build_vrt_capture.yml
+++ b/.github/workflows/sample_build_vrt_capture.yml
@@ -1,0 +1,49 @@
+name: Sample build VRT Capture
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  capture:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install Node dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Capture dist
+        run: bash ./.github/scripts/capture_sample_build_vrt_data.sh
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist-vrt-data
+          path: dist
+
+      - uses: actions/github-script@v9
+        env:
+          SUCCESSOR_NAME: ${{ github.event_name == 'pull_request' && 'pr_checks' || 'publish_baseline' }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.payload.pull_request?.head?.sha || context.sha;
+
+            await github.rest.repos.createCommitStatus({
+              owner, repo, sha,
+              state: "pending",
+              context: `sample-build-vrt-report / ${process.env.SUCCESSOR_NAME}`,
+            });

--- a/.github/workflows/sample_build_vrt_report.yml
+++ b/.github/workflows/sample_build_vrt_report.yml
@@ -1,0 +1,256 @@
+name: Sample build VRT Report
+
+on:
+  workflow_run:
+    workflows: ["Sample build VRT Capture"]
+    types: [completed]
+
+jobs:
+  publish_baseline:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      statuses: write
+    steps:
+      - uses: actions/github-script@v9
+        env:
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.payload.workflow_run.head_sha;
+
+            await github.rest.repos.createCommitStatus({
+              owner, repo, sha,
+              state: "pending",
+              context: "sample-build-vrt-report / publish_baseline",
+              target_url: process.env.RUN_URL,
+            });
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: sample-build-vrt-data
+          path: ./actual
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Archive baseline
+        run: tar -I 'zstd -19' -cf saved.tar.zst -C ./actual .
+
+      - uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          wranglerVersion: "4.91.0"
+          command: |
+            r2 object put ${{ secrets.VRT_CF_R2_BUCKET }}/visual-regression/sample-build-vrt/saved.tar.zst --file ./saved.tar.zst --remote
+
+      - if: always()
+        uses: actions/github-script@v9
+        env:
+          JOB_STATUS: ${{ job.status }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.payload.workflow_run.head_sha;
+
+            const mapping = {
+              success: "success",
+              failure: "failure",
+              cancelled: "error",
+            };
+            await github.rest.repos.createCommitStatus({
+              owner, repo, sha,
+              state: mapping[process.env.JOB_STATUS],
+              context: "sample-build-vrt-report / publish_baseline",
+              target_url: process.env.RUN_URL,
+            });
+
+  pr_checks:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      issues: write
+      pull-requests: write
+      statuses: write
+    steps:
+      - uses: actions/github-script@v9
+        env:
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.payload.workflow_run.head_sha;
+
+            await github.rest.repos.createCommitStatus({
+              owner, repo, sha,
+              state: "pending",
+              context: "sample-build-vrt-report / pr_checks",
+              target_url: process.env.RUN_URL,
+            });
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: sample-build-vrt-data
+          path: ./actual
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - continue-on-error: true
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          wranglerVersion: "4.91.0"
+          command: |
+            r2 object get ${{ secrets.VRT_CF_R2_BUCKET }}/visual-regression/sample-build-vrt/saved.tar.zst --file main-saved.tar.zst --remote
+
+      - name: Unpack baseline
+        run: |
+          set -euo pipefail
+          if [ ! -f main-saved.tar.zst ]; then
+            echo "::error title=Sample build VRT baseline is missing::Run Sample build VRT Capture on main once to publish the baseline."
+            exit 1
+          fi
+
+          mkdir -p expected
+          tar -xaf main-saved.tar.zst -C expected
+
+      - name: Install semdiff
+        run: |
+          set -euo pipefail
+          release="$(curl -fsSL "https://api.github.com/repos/White-Green/semdiff/releases/latest")"
+          download_url="$(echo "${release}" | jq -r '.assets[] | select(.name | contains("x86_64-unknown-linux")) | .browser_download_url' | head -n 1)"
+          if [ -z "${download_url}" ]; then
+            echo "Could not find semdiff Linux release asset" >&2
+            exit 1
+          fi
+
+          mkdir -p .github/tmp
+          curl -fsSL "${download_url}" --output .github/tmp/semdiff.tar.gz
+          tar -xaf .github/tmp/semdiff.tar.gz -C .github/tmp
+
+      - name: Compare sample build snapshots
+        id: compare
+        run: |
+          set -euo pipefail
+          mkdir -p regression data/sample-build-vrt/report
+
+          .github/tmp/semdiff/semdiff \
+            ./expected \
+            ./actual \
+            --json-ignore-object-key-order \
+            --json-ignore-path '$.updated' \
+            --output-html ./regression/index.html \
+            --output-json ./data/sample-build-vrt/report/report.json
+
+          cat ./data/sample-build-vrt/report/report.json
+          diff_count="$(jq '.modified + .added + .deleted' ./data/sample-build-vrt/report/report.json)"
+          echo "diff_count=${diff_count}" >> "$GITHUB_OUTPUT"
+
+      - uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          wranglerVersion: "4.91.0"
+          command: |
+            pages deploy --project-name ${{ vars.VRT_CF_PAGES_PROJECT_NAME }} --branch pr-${{ github.event.workflow_run.pull_requests[0].number }} ./regression
+
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require("fs");
+            const report = JSON.parse(fs.readFileSync("./data/sample-build-vrt/report/report.json", "utf8"));
+            const issue_number = context.payload.workflow_run.pull_requests[0].number;
+            const marker = "<!-- sample-build-vrt-diff-marker -->";
+
+            const body = `${marker}
+            ## Sample build Visual Regression Test Summary
+
+            | Category  | Count               |
+            |-----------|---------------------|
+            | Unchanged | ${report.unchanged} |
+            | Modified  | ${report.modified}  |
+            | Added     | ${report.added}     |
+            | Deleted   | ${report.deleted}   |
+
+            [Diff Report](https://pr-${issue_number}.${{ vars.VRT_CF_PAGES_PROJECT_NAME }}.pages.dev/)
+            `;
+
+            const { owner, repo } = context.repo;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const oldComments = comments.filter((comment) => comment.body.includes(marker));
+            for (const { node_id: nodeId } of oldComments) {
+              const mutation = `
+                mutation($subjectId: ID!) {
+                  minimizeComment(input: {
+                    subjectId: $subjectId,
+                    classifier: OUTDATED
+                  }) {
+                    minimizedComment {
+                      isMinimized
+                      minimizedReason
+                    }
+                  }
+                }
+              `;
+
+              await github.graphql(mutation, { subjectId: nodeId });
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body,
+            });
+
+      - name: Fail on sample build diff
+        if: steps.compare.outputs.diff_count != '0'
+        run: |
+          echo "::error title=Sample build VRT failed::Generated Sample build output differs from the main baseline. Review the Cloudflare Pages diff report."
+          exit 1
+
+      - name: Upload Sample build VRT report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sample-build-vrt-report
+          path: |
+            actual
+            expected
+            data/sample-build-vrt/report
+            regression
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - if: always()
+        uses: actions/github-script@v9
+        env:
+          JOB_STATUS: ${{ job.status }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.payload.workflow_run.head_sha;
+
+            const mapping = {
+              success: "success",
+              failure: "failure",
+              cancelled: "error",
+            };
+            await github.rest.repos.createCommitStatus({
+              owner, repo, sha,
+              state: mapping[process.env.JOB_STATUS],
+              context: "sample-build-vrt-report / pr_checks",
+              target_url: process.env.RUN_URL,
+            });


### PR DESCRIPTION
## 概要
- サンプルブログデータをビルドし、生成された`dist/`全体をartifactとしてアップロードするDist VRT capture workflowを追加します。
- `White-Green/semdiff`と同じ流れに合わせて、`main` push時はR2上のbaselineを更新し、pull request時はそのbaselineとの差分を比較します。
- PR差分がある場合は、HTML差分レポートをCloudflare Pagesへデプロイし、PRへコメントを投稿したうえでcheckを失敗させます。
- `semdiff`のlatest releaseを使用し、JSONについては`--json-ignore-path '$.updated'`でbuildごとに変わる`updated`だけを比較対象から除外します。

## 検証
- 最新の`origin/main`へrebase済みです。
- `capture_dist_vrt_data.sh`は`dist/`を生成するだけにし、artifact uploadで`dist`を直接指定する構成にしました。
- Bashの構文チェックを通しています。
- RubyのYAML parserで追加workflowを読み込めることを確認しました。
- `semdiff`のlatest releaseが`v0.4.0`で、`--json-ignore-path`を持っていることを確認しました。
- `git diff --check`を実行済みです。

## 注意点
- CI実行には`secrets.CF_API_TOKEN`、`secrets.CF_ACCOUNT_ID`、`secrets.VRT_CF_R2_BUCKET`、`vars.VRT_CF_PAGES_PROJECT_NAME`が必要です。
- 初回は`main`でworkflowを成功させ、R2に初期baselineを作成する必要があります。