### PR TITLE
Remove pnpm-lock override to fix CI frozen-lockfile mismatch

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  ws@>=8.0.0 <8.20.1: '>=8.20.1'
-
 importers:
 
   .:


### PR DESCRIPTION
### Motivation
- Remove a stale `overrides` entry in `pnpm-lock.yaml` that caused CI to fail under `--frozen-lockfile` due to lockfile drift.

### Description
- Deleted the `overrides` section (`ws@>=8.0.0 <8.20.1`) from `pnpm-lock.yaml` so the lockfile matches the current `package.json` dependency declarations.

### Testing
- Ran `pnpm install --frozen-lockfile` which completed successfully and confirmed with `git status --short` that only `pnpm-lock.yaml` changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d6fcbd9c483289446030599714707)