### PR TITLE
[codex] Add Cloudflare Access admin auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "askama"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf825125edd887a019d0a3a837dcc5499a68b0d034cc3eb594070c3e18addc"
+dependencies = [
+ "askama_macros",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c7065972a130eafa84215f21352ae15b4a7393da48c1f5e103904490736738"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "glob",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "askama_macros"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e23b1d2c4bd39a41971f6124cef4cc6fd0540913ecb90919b69ab3bbe44ae1a"
+dependencies = [
+ "askama_derive",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db09fde9143e7ac4513358fb32ee32847125b63b18ea715afd487956da715da"
+dependencies = [
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "unicode-ident",
+ "winnow",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +222,15 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -531,6 +593,7 @@ name = "fblog_system_core"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
+ "askama",
  "axum",
  "base64",
  "bitflags",
@@ -557,6 +620,7 @@ version = "0.1.0"
 dependencies = [
  "arrayvec",
  "axum",
+ "base64",
  "bytes",
  "chrono",
  "console_error_panic_hook",
@@ -782,6 +846,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"
@@ -2928,6 +2998,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ worker-build = "0.8.3"
 fblog_system_core = { path = "crates/core" }
 
 arrayvec = { features = ["serde"], version = "0.7.6" }
+askama = "0.16.0"
 axum = { default-features = false, features = ["json", "macros", "query"], version = "0.8.9" }
 base64 = "0.22.1"
 bitflags = "2.13.0"

--- a/crates/cloudflare_workers/Cargo.toml
+++ b/crates/cloudflare_workers/Cargo.toml
@@ -25,6 +25,7 @@ fblog_system_core = { workspace = true }
 
 arrayvec = { workspace = true }
 axum = { workspace = true }
+base64 = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 console_error_panic_hook = { workspace = true }

--- a/crates/cloudflare_workers/src/admin_auth.rs
+++ b/crates/cloudflare_workers/src/admin_auth.rs
@@ -142,10 +142,10 @@ pub async fn authenticate_admin_request(request: AdminAuthRequest) -> Result<(),
         return Err(AdminAuthError::UnauthorizedEmail);
     }
 
-    if let Some(header_email) = request.header_email {
-        if !emails_match(&header_email, email) {
-            return Err(AdminAuthError::InvalidEmailHeader);
-        }
+    if let Some(header_email) = request.header_email
+        && !emails_match(&header_email, email)
+    {
+        return Err(AdminAuthError::InvalidEmailHeader);
     }
 
     Ok(())

--- a/crates/cloudflare_workers/src/admin_auth.rs
+++ b/crates/cloudflare_workers/src/admin_auth.rs
@@ -1,4 +1,5 @@
 use axum::body::Body;
+use axum::extract::Request;
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use chrono::Utc;
@@ -6,7 +7,8 @@ use http::StatusCode;
 use http::header::CONTENT_TYPE;
 use ring::signature::{RSA_PKCS1_2048_8192_SHA256, RsaPublicKeyComponents};
 use serde::Deserialize;
-use worker::{Env, HttpRequest};
+use worker::Env;
+use worker::send::SendFuture;
 
 const ACCESS_JWT_HEADER: &str = "cf-access-jwt-assertion";
 const ACCESS_EMAIL_HEADER: &str = "cf-access-authenticated-user-email";
@@ -50,6 +52,12 @@ struct AdminAuthConfig {
     admin_email: String,
     team_domain: String,
     policy_aud: String,
+}
+
+pub struct AdminAuthRequest {
+    config: AdminAuthConfig,
+    header_email: Option<String>,
+    token: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -109,27 +117,33 @@ impl Audience {
     }
 }
 
-pub fn is_admin_path(path: &str) -> bool {
-    path == "/admin" || path.starts_with("/admin/")
-}
-
-pub async fn authenticate_admin_request(req: &HttpRequest, env: &Env) -> Result<(), AdminAuthError> {
+pub fn read_admin_auth_request(req: &Request, env: &Env) -> Result<AdminAuthRequest, AdminAuthError> {
     let config = AdminAuthConfig::from_env(env)?;
     let token = req
         .headers()
         .get(ACCESS_JWT_HEADER)
         .and_then(|value| value.to_str().ok())
+        .map(str::to_owned)
         .ok_or(AdminAuthError::MissingJwt)?;
+    let header_email = req
+        .headers()
+        .get(ACCESS_EMAIL_HEADER)
+        .map(|value| value.to_str().map(str::to_owned))
+        .transpose()
+        .map_err(|_| AdminAuthError::InvalidEmailHeader)?;
 
-    let claims = validate_access_jwt(token, &config).await?;
+    Ok(AdminAuthRequest { config, header_email, token })
+}
+
+pub async fn authenticate_admin_request(request: AdminAuthRequest) -> Result<(), AdminAuthError> {
+    let claims = validate_access_jwt(&request.token, &request.config).await?;
     let email = claims.email.as_deref().ok_or(AdminAuthError::InvalidJwt("missing email claim"))?;
-    if !emails_match(email, &config.admin_email) {
+    if !emails_match(email, &request.config.admin_email) {
         return Err(AdminAuthError::UnauthorizedEmail);
     }
 
-    if let Some(header_email) = req.headers().get(ACCESS_EMAIL_HEADER) {
-        let header_email = header_email.to_str().map_err(|_| AdminAuthError::InvalidEmailHeader)?;
-        if !emails_match(header_email, email) {
+    if let Some(header_email) = request.header_email {
+        if !emails_match(&header_email, email) {
             return Err(AdminAuthError::InvalidEmailHeader);
         }
     }
@@ -205,11 +219,14 @@ fn decode_json<T: for<'de> Deserialize<'de>>(encoded: &str) -> Result<T, AdminAu
 
 async fn fetch_access_certs(team_domain: &str) -> Result<AccessCerts, AdminAuthError> {
     let url = format!("{team_domain}/cdn-cgi/access/certs");
-    let response = reqwest::get(url).await.map_err(AdminAuthError::FetchCerts)?;
-    if !response.status().is_success() {
-        return Err(AdminAuthError::CertsStatus(response.status()));
-    }
-    response.json::<AccessCerts>().await.map_err(AdminAuthError::FetchCerts)
+    SendFuture::new(async move {
+        let response = reqwest::get(url).await.map_err(AdminAuthError::FetchCerts)?;
+        if !response.status().is_success() {
+            return Err(AdminAuthError::CertsStatus(response.status()));
+        }
+        response.json::<AccessCerts>().await.map_err(AdminAuthError::FetchCerts)
+    })
+    .await
 }
 
 fn verify_claims(claims: &AccessClaims, config: &AdminAuthConfig) -> Result<(), AdminAuthError> {

--- a/crates/cloudflare_workers/src/admin_auth.rs
+++ b/crates/cloudflare_workers/src/admin_auth.rs
@@ -1,0 +1,267 @@
+use axum::body::Body;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use chrono::Utc;
+use http::StatusCode;
+use http::header::CONTENT_TYPE;
+use ring::signature::{RSA_PKCS1_2048_8192_SHA256, RsaPublicKeyComponents};
+use serde::Deserialize;
+use worker::{Env, HttpRequest};
+
+const ACCESS_JWT_HEADER: &str = "cf-access-jwt-assertion";
+const ACCESS_EMAIL_HEADER: &str = "cf-access-authenticated-user-email";
+const ADMIN_EMAIL_VAR: &str = "ADMIN_EMAIL";
+const TEAM_DOMAIN_VAR: &str = "CLOUDFLARE_ACCESS_TEAM_DOMAIN";
+const POLICY_AUD_VAR: &str = "CLOUDFLARE_ACCESS_AUD";
+
+#[derive(Debug)]
+pub enum AdminAuthError {
+    MissingConfig(&'static str),
+    MissingJwt,
+    InvalidJwt(&'static str),
+    InvalidEmailHeader,
+    UnauthorizedEmail,
+    FetchCerts(reqwest::Error),
+    CertsStatus(reqwest::StatusCode),
+    Decode(base64::DecodeError),
+    Json(serde_json::Error),
+    Signature,
+}
+
+impl AdminAuthError {
+    pub fn log_message(&self) -> String {
+        match self {
+            Self::MissingConfig(name) => format!("missing config: {name}"),
+            Self::MissingJwt => "missing Cloudflare Access JWT".to_string(),
+            Self::InvalidJwt(reason) => format!("invalid Cloudflare Access JWT: {reason}"),
+            Self::InvalidEmailHeader => "invalid Cloudflare Access email header".to_string(),
+            Self::UnauthorizedEmail => "unauthorized admin email".to_string(),
+            Self::FetchCerts(error) => format!("failed to fetch Cloudflare Access certs: {error}"),
+            Self::CertsStatus(status) => format!("Cloudflare Access certs returned {status}"),
+            Self::Decode(error) => format!("failed to decode Cloudflare Access JWT: {error}"),
+            Self::Json(error) => format!("failed to parse Cloudflare Access JWT JSON: {error}"),
+            Self::Signature => "invalid Cloudflare Access JWT signature".to_string(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct AdminAuthConfig {
+    admin_email: String,
+    team_domain: String,
+    policy_aud: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct JwtHeader {
+    alg: String,
+    kid: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AccessClaims {
+    aud: Audience,
+    email: Option<String>,
+    exp: i64,
+    iss: String,
+    nbf: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum Audience {
+    One(String),
+    Many(Vec<String>),
+}
+
+#[derive(Debug, Deserialize)]
+struct AccessCerts {
+    keys: Vec<AccessJwk>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AccessJwk {
+    alg: Option<String>,
+    e: String,
+    kid: String,
+    kty: String,
+    n: String,
+    #[serde(rename = "use")]
+    key_use: Option<String>,
+}
+
+impl AdminAuthConfig {
+    fn from_env(env: &Env) -> Result<Self, AdminAuthError> {
+        Ok(Self {
+            admin_email: required_var(env, ADMIN_EMAIL_VAR)?,
+            team_domain: normalize_team_domain(required_var(env, TEAM_DOMAIN_VAR)?),
+            policy_aud: required_var(env, POLICY_AUD_VAR)?,
+        })
+    }
+}
+
+impl Audience {
+    fn contains(&self, expected: &str) -> bool {
+        match self {
+            Self::One(aud) => aud == expected,
+            Self::Many(audiences) => audiences.iter().any(|aud| aud == expected),
+        }
+    }
+}
+
+pub fn is_admin_path(path: &str) -> bool {
+    path == "/admin" || path.starts_with("/admin/")
+}
+
+pub async fn authenticate_admin_request(req: &HttpRequest, env: &Env) -> Result<(), AdminAuthError> {
+    let config = AdminAuthConfig::from_env(env)?;
+    let token = req
+        .headers()
+        .get(ACCESS_JWT_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .ok_or(AdminAuthError::MissingJwt)?;
+
+    let claims = validate_access_jwt(token, &config).await?;
+    let email = claims.email.as_deref().ok_or(AdminAuthError::InvalidJwt("missing email claim"))?;
+    if !emails_match(email, &config.admin_email) {
+        return Err(AdminAuthError::UnauthorizedEmail);
+    }
+
+    if let Some(header_email) = req.headers().get(ACCESS_EMAIL_HEADER) {
+        let header_email = header_email.to_str().map_err(|_| AdminAuthError::InvalidEmailHeader)?;
+        if !emails_match(header_email, email) {
+            return Err(AdminAuthError::InvalidEmailHeader);
+        }
+    }
+
+    Ok(())
+}
+
+pub fn forbidden_response() -> http::Response<Body> {
+    http::Response::builder()
+        .status(StatusCode::FORBIDDEN)
+        .header(CONTENT_TYPE, "text/plain; charset=utf-8")
+        .body(Body::from("Forbidden"))
+        .unwrap()
+}
+
+async fn validate_access_jwt(token: &str, config: &AdminAuthConfig) -> Result<AccessClaims, AdminAuthError> {
+    let ParsedJwt {
+        header,
+        claims,
+        signing_input,
+        signature,
+    } = parse_jwt(token)?;
+
+    if header.alg != "RS256" {
+        return Err(AdminAuthError::InvalidJwt("unsupported alg"));
+    }
+
+    verify_claims(&claims, config)?;
+    let certs = fetch_access_certs(&config.team_domain).await?;
+    let key = certs
+        .keys
+        .iter()
+        .find(|key| key.kid == header.kid)
+        .ok_or(AdminAuthError::InvalidJwt("unknown kid"))?;
+    verify_key_metadata(key)?;
+    verify_signature(key, signing_input.as_bytes(), &signature)?;
+
+    Ok(claims)
+}
+
+struct ParsedJwt {
+    header: JwtHeader,
+    claims: AccessClaims,
+    signing_input: String,
+    signature: Vec<u8>,
+}
+
+fn parse_jwt(token: &str) -> Result<ParsedJwt, AdminAuthError> {
+    let mut parts = token.split('.');
+    let header_part = parts.next().ok_or(AdminAuthError::InvalidJwt("missing header"))?;
+    let claims_part = parts.next().ok_or(AdminAuthError::InvalidJwt("missing claims"))?;
+    let signature_part = parts.next().ok_or(AdminAuthError::InvalidJwt("missing signature"))?;
+    if parts.next().is_some() {
+        return Err(AdminAuthError::InvalidJwt("too many jwt parts"));
+    }
+
+    let header = decode_json(header_part)?;
+    let claims = decode_json(claims_part)?;
+    let signature = URL_SAFE_NO_PAD.decode(signature_part).map_err(AdminAuthError::Decode)?;
+
+    Ok(ParsedJwt {
+        header,
+        claims,
+        signing_input: format!("{header_part}.{claims_part}"),
+        signature,
+    })
+}
+
+fn decode_json<T: for<'de> Deserialize<'de>>(encoded: &str) -> Result<T, AdminAuthError> {
+    let decoded = URL_SAFE_NO_PAD.decode(encoded).map_err(AdminAuthError::Decode)?;
+    serde_json::from_slice(&decoded).map_err(AdminAuthError::Json)
+}
+
+async fn fetch_access_certs(team_domain: &str) -> Result<AccessCerts, AdminAuthError> {
+    let url = format!("{team_domain}/cdn-cgi/access/certs");
+    let response = reqwest::get(url).await.map_err(AdminAuthError::FetchCerts)?;
+    if !response.status().is_success() {
+        return Err(AdminAuthError::CertsStatus(response.status()));
+    }
+    response.json::<AccessCerts>().await.map_err(AdminAuthError::FetchCerts)
+}
+
+fn verify_claims(claims: &AccessClaims, config: &AdminAuthConfig) -> Result<(), AdminAuthError> {
+    if normalize_team_domain(claims.iss.clone()) != config.team_domain {
+        return Err(AdminAuthError::InvalidJwt("issuer mismatch"));
+    }
+    if !claims.aud.contains(&config.policy_aud) {
+        return Err(AdminAuthError::InvalidJwt("audience mismatch"));
+    }
+
+    let now = Utc::now().timestamp();
+    if claims.exp <= now {
+        return Err(AdminAuthError::InvalidJwt("expired"));
+    }
+    if claims.nbf.is_some_and(|nbf| nbf > now) {
+        return Err(AdminAuthError::InvalidJwt("not yet valid"));
+    }
+
+    Ok(())
+}
+
+fn verify_key_metadata(key: &AccessJwk) -> Result<(), AdminAuthError> {
+    if key.kty != "RSA" {
+        return Err(AdminAuthError::InvalidJwt("unsupported key type"));
+    }
+    if key.alg.as_deref().is_some_and(|alg| alg != "RS256") {
+        return Err(AdminAuthError::InvalidJwt("unsupported key alg"));
+    }
+    if key.key_use.as_deref().is_some_and(|key_use| key_use != "sig") {
+        return Err(AdminAuthError::InvalidJwt("unsupported key use"));
+    }
+    Ok(())
+}
+
+fn verify_signature(key: &AccessJwk, signing_input: &[u8], signature: &[u8]) -> Result<(), AdminAuthError> {
+    let n = URL_SAFE_NO_PAD.decode(&key.n).map_err(AdminAuthError::Decode)?;
+    let e = URL_SAFE_NO_PAD.decode(&key.e).map_err(AdminAuthError::Decode)?;
+    RsaPublicKeyComponents { n: &n, e: &e }
+        .verify(&RSA_PKCS1_2048_8192_SHA256, signing_input, signature)
+        .map_err(|_| AdminAuthError::Signature)
+}
+
+fn required_var(env: &Env, name: &'static str) -> Result<String, AdminAuthError> {
+    env.var(name)
+        .map(|value| value.to_string())
+        .map_err(|_| AdminAuthError::MissingConfig(name))
+}
+
+fn normalize_team_domain(value: String) -> String {
+    value.trim_end_matches('/').to_string()
+}
+
+fn emails_match(left: &str, right: &str) -> bool {
+    left.trim().eq_ignore_ascii_case(right.trim())
+}

--- a/crates/cloudflare_workers/src/lib.rs
+++ b/crates/cloudflare_workers/src/lib.rs
@@ -4,8 +4,10 @@ use axum::http::Request;
 use axum::response::IntoResponse;
 use bytes::Bytes;
 use chrono::Utc;
+#[cfg(feature = "activitypub")]
 use fblog_system_core::process_queue::{ProcessQueueResult, process_queue};
-use fblog_system_core::route::router;
+#[cfg(feature = "activitypub")]
+use fblog_system_core::route::{admin_router, router};
 use fblog_system_core::traits::*;
 use futures::Stream;
 use futures::stream::TryStreamExt;
@@ -16,12 +18,18 @@ use std::fmt::Display;
 use std::mem;
 use std::pin::Pin;
 use std::task::{Context as TaskContext, Poll};
+#[cfg(feature = "activitypub")]
 use tower_service::Service;
 use tracing_subscriber::fmt::format::Pretty;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_web::MakeConsoleWriter;
-use worker::{Context, Env, HttpRequest, MessageExt, event};
+#[cfg(feature = "activitypub")]
+use worker::MessageExt;
+use worker::{Context, Env, HttpRequest, event};
+
+#[cfg(feature = "activitypub")]
+mod admin_auth;
 
 #[cfg(feature = "test")]
 mod tests;
@@ -75,6 +83,12 @@ impl fblog_system_core::traits::Env for WorkerState {
     }
     fn signing_key(&self) -> &RSASHA2SigningKey {
         &self.signing_key
+    }
+}
+
+impl AdminProvider for WorkerState {
+    async fn admin_dashboard(&self) -> AdminDashboard {
+        AdminDashboard::default()
     }
 }
 
@@ -476,6 +490,14 @@ compile_error!("Cannot enable both preview and activitypub features at the same 
 #[cfg(feature = "activitypub")]
 #[event(fetch)]
 async fn fetch(req: HttpRequest, env: Env, _ctx: Context) -> worker::Result<http::Response<Body>> {
+    if admin_auth::is_admin_path(req.uri().path()) {
+        if let Err(error) = admin_auth::authenticate_admin_request(&req, &env).await {
+            tracing::warn!(error = %error.log_message(), "admin request rejected");
+            return Ok(admin_auth::forbidden_response());
+        }
+        let state = setup_worker_state(&env)?;
+        return Ok(admin_router(state.clone()).with_state::<()>(state).call(req).await?);
+    }
     let state = setup_worker_state(&env)?;
     Ok(router(state.clone()).with_state::<()>(state).call(req).await?)
 }

--- a/crates/cloudflare_workers/src/lib.rs
+++ b/crates/cloudflare_workers/src/lib.rs
@@ -1,7 +1,13 @@
 use arrayvec::ArrayVec;
 use axum::body::Body;
-use axum::http::Request;
+#[cfg(feature = "activitypub")]
+use axum::extract::Request as AxumRequest;
+use axum::http::Request as HttpBodyRequest;
+#[cfg(feature = "activitypub")]
+use axum::middleware::{self, Next};
 use axum::response::IntoResponse;
+#[cfg(feature = "activitypub")]
+use axum::response::Response as AxumResponse;
 use bytes::Bytes;
 use chrono::Utc;
 #[cfg(feature = "activitypub")]
@@ -435,7 +441,7 @@ impl Queue for WorkerState {
 
 impl HTTPClient for WorkerState {
     type Error = reqwest::Error;
-    async fn request(&self, request: Request<Bytes>) -> Result<axum::http::Response<Body>, Self::Error> {
+    async fn request(&self, request: HttpBodyRequest<Bytes>) -> Result<axum::http::Response<Body>, Self::Error> {
         let req = reqwest::Request::try_from(request)?;
         worker::send::SendFuture::new(async move {
             let mut resp = reqwest::Client::new().execute(req).await?;
@@ -490,16 +496,29 @@ compile_error!("Cannot enable both preview and activitypub features at the same 
 #[cfg(feature = "activitypub")]
 #[event(fetch)]
 async fn fetch(req: HttpRequest, env: Env, _ctx: Context) -> worker::Result<http::Response<Body>> {
-    if admin_auth::is_admin_path(req.uri().path()) {
-        if let Err(error) = admin_auth::authenticate_admin_request(&req, &env).await {
-            tracing::warn!(error = %error.log_message(), "admin request rejected");
-            return Ok(admin_auth::forbidden_response());
-        }
-        let state = setup_worker_state(&env)?;
-        return Ok(admin_router(state.clone()).with_state::<()>(state).call(req).await?);
-    }
     let state = setup_worker_state(&env)?;
-    Ok(router(state.clone()).with_state::<()>(state).call(req).await?)
+    let auth_state = state.clone();
+    let admin = admin_router(state.clone()).layer(middleware::from_fn(move |req, next| {
+        let auth_state = auth_state.clone();
+        async move { require_admin_access(auth_state, req, next).await }
+    }));
+    Ok(router(state.clone()).nest("/admin", admin).with_state::<()>(state).call(req).await?)
+}
+
+#[cfg(feature = "activitypub")]
+async fn require_admin_access(state: WorkerState, req: AxumRequest, next: Next) -> AxumResponse {
+    let auth_request = match admin_auth::read_admin_auth_request(&req, &state.env) {
+        Ok(auth_request) => auth_request,
+        Err(error) => {
+            tracing::warn!(error = %error.log_message(), "admin request rejected");
+            return admin_auth::forbidden_response();
+        }
+    };
+    if let Err(error) = admin_auth::authenticate_admin_request(auth_request).await {
+        tracing::warn!(error = %error.log_message(), "admin request rejected");
+        return admin_auth::forbidden_response();
+    }
+    next.run(req).await
 }
 
 #[cfg(feature = "test")]

--- a/crates/cloudflare_workers/wrangler.template.toml
+++ b/crates/cloudflare_workers/wrangler.template.toml
@@ -20,6 +20,8 @@ bucket_name = '${PROJECT_NAME}-blog-bucket'
 
 [vars]
 URL = "https://${HOST_NAME}"
+# Configure these Worker variables outside of this template before enabling /admin:
+# ADMIN_EMAIL, CLOUDFLARE_ACCESS_TEAM_DOMAIN, CLOUDFLARE_ACCESS_AUD
 
 [[d1_databases]]
 binding = "BLOG_DB"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -6,6 +6,7 @@ version = { workspace = true }
 
 [dependencies]
 arrayvec = { workspace = true }
+askama = { workspace = true }
 axum = { workspace = true }
 base64 = { workspace = true }
 bitflags = { workspace = true }

--- a/crates/core/src/route.rs
+++ b/crates/core/src/route.rs
@@ -28,8 +28,5 @@ pub fn admin_router<E, S>(state: E) -> Router<S>
 where
     E: AdminProvider + Send + Sync + Clone + 'static,
 {
-    Router::<E>::new()
-        .route("/admin", get(admin::admin_get::<E>))
-        .route("/admin/", get(admin::admin_get::<E>))
-        .with_state(state)
+    Router::<E>::new().route("/", get(admin::admin_get::<E>)).with_state(state)
 }

--- a/crates/core/src/route.rs
+++ b/crates/core/src/route.rs
@@ -1,7 +1,8 @@
-use crate::traits::{ArticleProvider, Env, HTTPClient, Queue, UserProvider};
+use crate::traits::{AdminProvider, ArticleProvider, Env, HTTPClient, Queue, UserProvider};
 use axum::Router;
 use axum::routing::{get, post};
 
+mod admin;
 mod articles;
 mod users;
 mod well_known;
@@ -20,5 +21,15 @@ where
         .route("/events/articles/create/{*slug}", get(articles::events::article_create_events_get::<E>))
         .route("/events/articles/update/{*slug}", get(articles::events::article_update_events_get::<E>))
         .route("/events/articles/delete/{*slug}", get(articles::events::article_delete_events_get::<E>))
+        .with_state(state)
+}
+
+pub fn admin_router<E, S>(state: E) -> Router<S>
+where
+    E: AdminProvider + Send + Sync + Clone + 'static,
+{
+    Router::<E>::new()
+        .route("/admin", get(admin::admin_get::<E>))
+        .route("/admin/", get(admin::admin_get::<E>))
         .with_state(state)
 }

--- a/crates/core/src/route/admin.rs
+++ b/crates/core/src/route/admin.rs
@@ -1,0 +1,44 @@
+use crate::traits::AdminProvider;
+use askama::Template;
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::http::header::CONTENT_TYPE;
+use axum::response::{IntoResponse, Response};
+
+#[derive(Template)]
+#[template(
+    source = r#"<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Admin</title>
+</head>
+<body>
+  <main>
+    <h1>Admin</h1>
+  </main>
+</body>
+</html>"#,
+    ext = "html"
+)]
+struct AdminTemplate;
+
+#[tracing::instrument(skip(state))]
+pub async fn admin_get<E>(State(state): State<E>) -> Response<Body>
+where
+    E: AdminProvider,
+{
+    let _dashboard = state.admin_dashboard().await;
+    match AdminTemplate.render() {
+        Ok(html) => Response::builder()
+            .header(CONTENT_TYPE, mime::TEXT_HTML.as_ref())
+            .body(Body::from(html))
+            .unwrap(),
+        Err(error) => {
+            tracing::error!(error = ?error, "failed to render admin dashboard");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -59,6 +59,13 @@ pub trait UserProvider {
     fn get_followers_inbox_batch(&self, username: &str, last_inbox: &str) -> impl Future<Output = (ArrayVec<String, 10>, String)> + Send;
 }
 
+#[derive(Debug, Default, Serialize)]
+pub struct AdminDashboard {}
+
+pub trait AdminProvider {
+    fn admin_dashboard(&self) -> impl Future<Output = AdminDashboard> + Send;
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(tag = "event_type")]
 pub enum QueueData {


### PR DESCRIPTION
## Summary
- Add a core `AdminProvider` and `admin_router` with an Askama-rendered placeholder root admin page.
- Mount the core admin router under `/admin` in the Cloudflare Workers crate and apply Cloudflare Access auth as middleware around that mount.
- Validate `Cf-Access-Jwt-Assertion` with the configured team JWKS, issuer, audience, and token time claims, then allow only the verified `email` claim matching `ADMIN_EMAIL`.

## Configuration
Set these Worker variables before using `/admin`:
- `ADMIN_EMAIL`
- `CLOUDFLARE_ACCESS_TEAM_DOMAIN`
- `CLOUDFLARE_ACCESS_AUD`

## Checks
- `cargo fmt --all`
- `cargo clippy --locked --workspace --tests -- -D warnings`
- `cargo check --workspace`
- `cargo check -p fblog_system_frontend_cloudflare_workers --target wasm32-unknown-unknown`
- `cargo check -p fblog_system_frontend_cloudflare_workers --no-default-features --features test`
- `cargo test -p fblog_system_core`