### PR TITLE
[codex] Pin binary tool versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,14 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - id: worker_build
+        name: Load worker-build version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(cargo metadata --no-deps --format-version 1 | jq -er '.metadata["cargo-binaries"]["worker-build"]')"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
       - name: Cache cargo
         uses: actions/cache@v5
         with:
@@ -39,6 +47,17 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('Cargo.lock') }}
           restore-keys: ${{ github.ref_name != github.event.repository.default_branch && format('{0}-cargo-test-', runner.os) }}
+
+      - id: worker_build_binary_cache
+        name: Restore worker-build cache
+        uses: actions/cache@v5
+        with:
+          key: fblog_system-cargo_install-worker-build-${{ steps.worker_build.outputs.version }}
+          path: ~/.cargo/bin/worker-build
+
+      - name: Install worker-build
+        if: steps.worker_build_binary_cache.outputs.cache-hit != 'true'
+        run: cargo install --locked "worker-build@${{ steps.worker_build.outputs.version }}" --force
 
       - run: cargo fetch --locked
 
@@ -194,27 +213,27 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: taplo-cli version
-        id: taplo-version
+      - uses: dtolnay/rust-toolchain@stable
+
+      - id: taplo_cli
+        name: Load taplo-cli version
         shell: bash
         run: |
-          V=$(curl https://index.crates.io/ta/pl/taplo-cli | jq -r 'select(.yanked == false) | .vers' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort --reverse --version-sort | head --lines=1)
-          echo "Latest version of taplo-cli: $V"
-          echo "version=$V" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          version="$(cargo metadata --no-deps --format-version 1 | jq -er '.metadata["cargo-binaries"]["taplo-cli"]')"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
-      - name: cache taplo-cli binary
-        id: taplo-cache
+      - id: taplo-cache
+        name: Restore taplo-cli cache
         uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/taplo
-          key: ${{ runner.os }}-taplo-cli-${{ steps.taplo-version.outputs.version }}
-
-      - uses: dtolnay/rust-toolchain@stable
-        if: steps.taplo-cache.outputs.cache-hit != 'true'
+          key: ${{ runner.os }}-taplo-cli-${{ steps.taplo_cli.outputs.version }}
 
       - name: install taplo-cli
         if: steps.taplo-cache.outputs.cache-hit != 'true'
-        run: cargo install taplo-cli@${{ steps.taplo-version.outputs.version }} --locked
+        run: |
+          cargo install --locked "taplo-cli@${{ steps.taplo_cli.outputs.version }}" --force
 
       - name: taplo fmt
         run: ~/.cargo/bin/taplo fmt --check

--- a/.github/workflows/deploy/cloudflare_workers/main/action.yml
+++ b/.github/workflows/deploy/cloudflare_workers/main/action.yml
@@ -54,24 +54,28 @@ runs:
       with:
         targets: wasm32-unknown-unknown
 
-    - id: crate_version
-      name: Determine worker-build version
+    - id: worker_build
+      name: Load worker-build version
+      working-directory: ${{ steps.normalized.outputs.working_dir }}
       shell: bash
       run: |
-        VER=$(curl https://index.crates.io/wo/rk/worker-build | jq -r 'select(.yanked == false) | .vers' | sort -V | tail -n 1)
-        echo "worker_build=$VER" >> $GITHUB_OUTPUT
+        set -euo pipefail
+        version="$(cargo metadata --no-deps --format-version 1 | jq -er '.metadata["cargo-binaries"]["worker-build"]')"
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
 
     - id: worker_build_binary_cache
       name: Restore worker-build cache
       uses: actions/cache@v5
       with:
-        key: fblog_system-cargo_install-${{ steps.crate_version.outputs.worker_build }}
+        key: fblog_system-cargo_install-worker-build-${{ steps.worker_build.outputs.version }}
         path: ~/.cargo/bin/worker-build
 
     - name: Install worker-build
       shell: bash
+      working-directory: ${{ steps.normalized.outputs.working_dir }}
       if: steps.worker_build_binary_cache.outputs.cache-hit != 'true'
-      run: cargo install --locked worker-build
+      run: |
+        cargo install --locked "worker-build@${{ steps.worker_build.outputs.version }}" --force
 
     - name: Compute build-cache key
       id: build_key

--- a/.github/workflows/deploy/cloudflare_workers/preview/action.yml
+++ b/.github/workflows/deploy/cloudflare_workers/preview/action.yml
@@ -65,24 +65,28 @@ runs:
       with:
         targets: wasm32-unknown-unknown
 
-    - id: crate_version
-      name: Determine worker-build version
+    - id: worker_build
+      name: Load worker-build version
+      working-directory: ${{ steps.normalized.outputs.working_dir }}
       shell: bash
       run: |
-        VER=$(curl https://index.crates.io/wo/rk/worker-build | jq -r 'select(.yanked == false) | .vers' | sort -V | tail -n 1)
-        echo "worker_build=$VER" >> $GITHUB_OUTPUT
+        set -euo pipefail
+        version="$(cargo metadata --no-deps --format-version 1 | jq -er '.metadata["cargo-binaries"]["worker-build"]')"
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
 
     - id: worker_build_binary_cache
       name: Restore worker-build cache
       uses: actions/cache@v5
       with:
-        key: fblog_system-cargo_install-${{ steps.crate_version.outputs.worker_build }}
+        key: fblog_system-cargo_install-worker-build-${{ steps.worker_build.outputs.version }}
         path: ~/.cargo/bin/worker-build
 
     - name: Install worker-build
       shell: bash
+      working-directory: ${{ steps.normalized.outputs.working_dir }}
       if: steps.worker_build_binary_cache.outputs.cache-hit != 'true'
-      run: cargo install --locked worker-build
+      run: |
+        cargo install --locked "worker-build@${{ steps.worker_build.outputs.version }}" --force
 
     - name: Compute build-cache key
       id: build_key

--- a/.github/workflows/sample_build_vrt_report.yml
+++ b/.github/workflows/sample_build_vrt_report.yml
@@ -5,6 +5,10 @@ on:
     workflows: ["Sample build VRT Capture"]
     types: [completed]
 
+env:
+  VRT_WRANGLER_VERSION: "4.91.0"
+  SEMDIFF_VERSION: "v0.4.2"
+
 jobs:
   publish_baseline:
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == github.event.repository.default_branch
@@ -42,7 +46,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          wranglerVersion: "4.91.0"
+          wranglerVersion: ${{ env.VRT_WRANGLER_VERSION }}
           command: |
             r2 object put ${{ secrets.VRT_CF_R2_BUCKET }}/visual-regression/sample-build-vrt/saved_tar_zst --file ./saved.tar.zst --remote
 
@@ -104,7 +108,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          wranglerVersion: "4.91.0"
+          wranglerVersion: ${{ env.VRT_WRANGLER_VERSION }}
           command: |
             r2 object get ${{ secrets.VRT_CF_R2_BUCKET }}/visual-regression/sample-build-vrt/saved_tar_zst --file main-saved.tar.zst --remote
 
@@ -122,12 +126,7 @@ jobs:
       - name: Install semdiff
         run: |
           set -euo pipefail
-          release="$(curl -fsSL "https://api.github.com/repos/White-Green/semdiff/releases/latest")"
-          download_url="$(echo "${release}" | jq -r '.assets[] | select(.name | contains("x86_64-unknown-linux")) | .browser_download_url' | head -n 1)"
-          if [ -z "${download_url}" ]; then
-            echo "Could not find semdiff Linux release asset" >&2
-            exit 1
-          fi
+          download_url="https://github.com/White-Green/semdiff/releases/download/${SEMDIFF_VERSION}/semdiff-x86_64-unknown-linux-musl.tar.gz"
 
           mkdir -p .github/tmp
           curl -fsSL "${download_url}" --output .github/tmp/semdiff.tar.gz
@@ -150,7 +149,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          wranglerVersion: "4.91.0"
+          wranglerVersion: ${{ env.VRT_WRANGLER_VERSION }}
           command: |
             pages deploy --project-name ${{ vars.VRT_CF_PAGES_PROJECT_NAME }} --branch pr-${{ github.event.workflow_run.pull_requests[0].number }} ./regression
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ version = "0.1.0"
 members = ["crates/cloudflare_workers", "crates/core", "crates/in_memory/server", "tests"]
 resolver = "2"
 
+[workspace.metadata.cargo-binaries]
+taplo-cli = "0.10.0"
+worker-build = "0.8.3"
+
 [workspace.dependencies]
 fblog_system_core = { path = "crates/core" }
 

--- a/crates/cloudflare_workers/wrangler.toml
+++ b/crates/cloudflare_workers/wrangler.toml
@@ -10,7 +10,7 @@ route = "local.test/*"
 workers_dev = false
 
 [build]
-command = "cargo install --locked worker-build && worker-build --no-default-features --features test"
+command = "worker-build --no-default-features --features test"
 
 [assets]
 binding = "ASSETS"

--- a/tests/src/cloudflare_workers.rs
+++ b/tests/src/cloudflare_workers.rs
@@ -12,11 +12,16 @@ pub struct CloudflareWorkers {
 impl CloudflareWorkers {
     pub fn new(client: Client) -> Self {
         let workspace_dir = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+        let cloudflare_workers_dir = workspace_dir.join("crates").join("cloudflare_workers");
         let port = 8788; // Use a different port than the in-memory server
 
-        let output = std::process::Command::new("pnpx")
-            .current_dir(workspace_dir.join("crates").join("cloudflare_workers"))
-            .args(["wrangler", "d1", "migrations", "apply", "BLOG_DB", "--local"])
+        let output = std::process::Command::new("pnpm")
+            .current_dir(workspace_dir)
+            .arg("exec")
+            .arg("wrangler")
+            .arg("--cwd")
+            .arg(&cloudflare_workers_dir)
+            .args(["d1", "migrations", "apply", "BLOG_DB", "--local"])
             .stderr(std::process::Stdio::inherit())
             .stdout(std::process::Stdio::inherit())
             .stdin(std::process::Stdio::null())
@@ -25,9 +30,16 @@ impl CloudflareWorkers {
         assert!(output.status.success());
 
         // Start wrangler dev with the test feature enabled
-        let process = std::process::Command::new("pnpx")
-            .current_dir(workspace_dir.join("crates").join("cloudflare_workers"))
-            .args(["wrangler", "dev", "--port", &port.to_string(), "--local"])
+        let process = std::process::Command::new("pnpm")
+            .current_dir(workspace_dir)
+            .arg("exec")
+            .arg("wrangler")
+            .arg("--cwd")
+            .arg(&cloudflare_workers_dir)
+            .arg("dev")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--local")
             .stderr(std::process::Stdio::inherit())
             .stdout(std::process::Stdio::inherit())
             .stdin(std::process::Stdio::null())


### PR DESCRIPTION
## Summary
- Pin Cargo-installed binary versions in `[workspace.metadata.cargo-binaries]` in `Cargo.toml`.
- Read `worker-build` and `taplo-cli` versions from `cargo metadata` in CI and deploy composite actions.
- Keep binary caches keyed by the pinned versions, including the `ci.yml` test job cache for `worker-build`.
- Install `worker-build` in workflows before wrangler invokes the build command; keep `wrangler*.toml` commands as direct `worker-build ...` invocations.
- Pin VRT `wranglerVersion` and semdiff release tag in one `env` block at the top of the VRT report workflow.
- Use `pnpm exec wrangler --cwd <cloudflare_workers_dir>` in the Cloudflare Workers test helper so the locked project wrangler is used with the correct wrangler working directory.

## Out of scope
- Renovate/custom update automation is intentionally left for a separate PR.

## Validation
- Confirmed `cargo metadata --no-deps --format-version 1` exposes `worker-build=0.8.3` and `taplo-cli=0.10.0`.
- Ran `taplo fmt` and `taplo fmt --check`.
- Ran `git diff --check origin/main...HEAD`.
- Confirmed `cargo install worker-build` appears only in workflows and not in `wrangler*.toml`.
- `cargo fmt --check --all` currently fails on existing CRLF newline style issues and stable rustfmt warnings for unstable rustfmt options.