### PR TITLE
[codex] Split Renovate npm and Cargo groups

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,11 +7,18 @@
 
   packageRules: [
     {
-      description: "Group npm and Cargo package patch/minor updates into one PR.",
-      matchManagers: ["npm", "cargo"],
+      description: "Group npm package patch/minor updates into one PR.",
+      matchManagers: ["npm"],
       matchUpdateTypes: ["patch", "minor"],
-      groupName: "npm and Cargo package patch/minor updates",
-      groupSlug: "npm-cargo-package-patch-minor",
+      groupName: "npm package patch/minor updates",
+      groupSlug: "npm-package-patch-minor",
+    },
+    {
+      description: "Group Cargo package patch/minor updates into one PR.",
+      matchManagers: ["cargo"],
+      matchUpdateTypes: ["patch", "minor"],
+      groupName: "Cargo package patch/minor updates",
+      groupSlug: "cargo-package-patch-minor",
     },
     {
       description: "Group binary version pins by binary name, without grouping different binaries together.",


### PR DESCRIPTION
## Summary
- Split Renovate patch/minor grouping for npm and Cargo package updates into separate groups.
- Keep Docker and binary grouping behavior unchanged.

## Validation
- `npm exec --yes --package renovate renovate-config-validator`
- `npm exec --yes --package renovate -- renovate --platform=local --dry-run=extract`
- `git diff --check origin/main...HEAD`