### PR TITLE
[codex] Add GitHub Actions workflow lint job

### DIFF
--- a/.github/actions/deploy/cloudflare_workers/main/action.yml
+++ b/.github/actions/deploy/cloudflare_workers/main/action.yml
@@ -4,9 +4,6 @@ inputs:
   working_dir:
     required: true
     type: string
-  preview_name:
-    required: true
-    type: string
   article_data_path:
     required: true
     type: string
@@ -32,26 +29,20 @@ inputs:
     required: true
     type: string
 
-outputs:
-  preview_url:
-    description: "Preview URL"
-    value: ${{ steps.outputs.outputs.preview_url }}
-  events_jsonl:
-    description: "events.jsonl"
-    value: ${{ steps.outputs.outputs.events_jsonl }}
-
 runs:
   using: "composite"
   steps:
     - id: normalized
       name: Normalize variables
       shell: bash
+      env:
+        WORKING_DIR_INPUT: ${{ inputs.working_dir }}
       run: |
-        WORKING_DIR="${{ inputs.working_dir }}"
-        echo "working_dir=${WORKING_DIR%/}" >> $GITHUB_OUTPUT
+        working_dir="${WORKING_DIR_INPUT%/}"
+        echo "working_dir=${working_dir}" >> "$GITHUB_OUTPUT"
 
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: '24'
 
@@ -61,7 +52,7 @@ runs:
       run: corepack enable
 
     - name: Setup Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@stable # zizmor: ignore[unpinned-uses] Channel refs select the requested Rust toolchain.
       with:
         targets: wasm32-unknown-unknown
 
@@ -76,7 +67,7 @@ runs:
 
     - id: worker_build_binary_cache
       name: Restore worker-build cache
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         key: fblog_system-cargo_install-worker-build-${{ steps.worker_build.outputs.version }}
         path: ~/.cargo/bin/worker-build
@@ -85,18 +76,20 @@ runs:
       shell: bash
       working-directory: ${{ steps.normalized.outputs.working_dir }}
       if: steps.worker_build_binary_cache.outputs.cache-hit != 'true'
+      env:
+        WORKER_BUILD_VERSION: ${{ steps.worker_build.outputs.version }}
       run: |
-        cargo install --locked "worker-build@${{ steps.worker_build.outputs.version }}" --force
+        cargo install --locked "worker-build@${WORKER_BUILD_VERSION}" --force
 
     - name: Compute build-cache key
       id: build_key
       working-directory: ${{ steps.normalized.outputs.working_dir }}
       shell: bash
       run: |
-        echo "cargo_lock_hash=$(sha256sum "Cargo.lock" | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+        echo "cargo_lock_hash=$(sha256sum "Cargo.lock" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
     - name: Restore build cache
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         key: fblog_system-build_cache-${{ steps.build_key.outputs.cargo_lock_hash }}
         path: /tmp/fblog_system_build_cache
@@ -106,29 +99,28 @@ runs:
       working-directory: ${{ steps.normalized.outputs.working_dir }}
       run: mv /tmp/fblog_system_build_cache ./target || true
 
-    - name: Deploy Cloudflare Workers (preview)
+    - name: Deploy Cloudflare Workers
       shell: bash
       env:
         CLOUDFLARE_ACCOUNT_ID: ${{ inputs.cloudflare_account_id }}
         CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare_api_token }}
+        WORKING_DIR: ${{ steps.normalized.outputs.working_dir }}
+        ARTICLE_DATA_PATH: ${{ inputs.article_data_path }}
+        USER_DATA_PATH: ${{ inputs.user_data_path }}
+        BUILD_DATA_PATH: ${{ inputs.build_data_path }}
+        PROJECT_NAME: ${{ inputs.project_name }}
+        SITE_URL: ${{ inputs.site_url }}
+        PUBLIC_KEY_PATH: ${{ inputs.public_key_path }}
       run: |
-        bash "${{ steps.normalized.outputs.working_dir }}/deploy_scripts/cloudflare/deploy_preview.sh" \
-          "${{ inputs.preview_name }}" \
-          "${{ inputs.article_data_path }}" \
-          "${{ inputs.user_data_path }}" \
-          "${{ inputs.build_data_path }}" \
-          "${{ inputs.project_name }}" \
-          "${{ inputs.site_url }}" \
-          "${{ inputs.public_key_path }}"
+        bash "${WORKING_DIR}/deploy_scripts/cloudflare/deploy_prod.sh" \
+          "${ARTICLE_DATA_PATH}" \
+          "${USER_DATA_PATH}" \
+          "${BUILD_DATA_PATH}" \
+          "${PROJECT_NAME}" \
+          "${SITE_URL}" \
+          "${PUBLIC_KEY_PATH}"
 
     - name: Save build cache
       shell: bash
       working-directory: ${{ steps.normalized.outputs.working_dir }}
       run: mv ./target /tmp/fblog_system_build_cache
-
-    - id: outputs
-      name: Set outputs
-      shell: bash
-      run: |
-        echo "events_jsonl=${{ steps.normalized.outputs.working_dir }}/events.jsonl" >> $GITHUB_OUTPUT
-        echo "preview_url=$(cat ${{ steps.normalized.outputs.working_dir }}/crates/cloudflare_workers/preview_url)" >> $GITHUB_OUTPUT

--- a/.github/actions/deploy/cloudflare_workers/preview/action.yml
+++ b/.github/actions/deploy/cloudflare_workers/preview/action.yml
@@ -4,6 +4,9 @@ inputs:
   working_dir:
     required: true
     type: string
+  preview_name:
+    required: true
+    type: string
   article_data_path:
     required: true
     type: string
@@ -29,18 +32,28 @@ inputs:
     required: true
     type: string
 
+outputs:
+  preview_url:
+    description: "Preview URL"
+    value: ${{ steps.outputs.outputs.preview_url }}
+  events_jsonl:
+    description: "events.jsonl"
+    value: ${{ steps.outputs.outputs.events_jsonl }}
+
 runs:
   using: "composite"
   steps:
     - id: normalized
       name: Normalize variables
       shell: bash
+      env:
+        WORKING_DIR_INPUT: ${{ inputs.working_dir }}
       run: |
-        WORKING_DIR="${{ inputs.working_dir }}"
-        echo "working_dir=${WORKING_DIR%/}" >> $GITHUB_OUTPUT
+        working_dir="${WORKING_DIR_INPUT%/}"
+        echo "working_dir=${working_dir}" >> "$GITHUB_OUTPUT"
 
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: '24'
 
@@ -50,7 +63,7 @@ runs:
       run: corepack enable
 
     - name: Setup Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@stable # zizmor: ignore[unpinned-uses] Channel refs select the requested Rust toolchain.
       with:
         targets: wasm32-unknown-unknown
 
@@ -65,7 +78,7 @@ runs:
 
     - id: worker_build_binary_cache
       name: Restore worker-build cache
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         key: fblog_system-cargo_install-worker-build-${{ steps.worker_build.outputs.version }}
         path: ~/.cargo/bin/worker-build
@@ -74,18 +87,20 @@ runs:
       shell: bash
       working-directory: ${{ steps.normalized.outputs.working_dir }}
       if: steps.worker_build_binary_cache.outputs.cache-hit != 'true'
+      env:
+        WORKER_BUILD_VERSION: ${{ steps.worker_build.outputs.version }}
       run: |
-        cargo install --locked "worker-build@${{ steps.worker_build.outputs.version }}" --force
+        cargo install --locked "worker-build@${WORKER_BUILD_VERSION}" --force
 
     - name: Compute build-cache key
       id: build_key
       working-directory: ${{ steps.normalized.outputs.working_dir }}
       shell: bash
       run: |
-        echo "cargo_lock_hash=$(sha256sum "Cargo.lock" | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+        echo "cargo_lock_hash=$(sha256sum "Cargo.lock" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
     - name: Restore build cache
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         key: fblog_system-build_cache-${{ steps.build_key.outputs.cargo_lock_hash }}
         path: /tmp/fblog_system_build_cache
@@ -95,21 +110,40 @@ runs:
       working-directory: ${{ steps.normalized.outputs.working_dir }}
       run: mv /tmp/fblog_system_build_cache ./target || true
 
-    - name: Deploy Cloudflare Workers
+    - name: Deploy Cloudflare Workers (preview)
       shell: bash
       env:
         CLOUDFLARE_ACCOUNT_ID: ${{ inputs.cloudflare_account_id }}
         CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare_api_token }}
+        WORKING_DIR: ${{ steps.normalized.outputs.working_dir }}
+        PREVIEW_NAME: ${{ inputs.preview_name }}
+        ARTICLE_DATA_PATH: ${{ inputs.article_data_path }}
+        USER_DATA_PATH: ${{ inputs.user_data_path }}
+        BUILD_DATA_PATH: ${{ inputs.build_data_path }}
+        PROJECT_NAME: ${{ inputs.project_name }}
+        SITE_URL: ${{ inputs.site_url }}
+        PUBLIC_KEY_PATH: ${{ inputs.public_key_path }}
       run: |
-        bash "${{ steps.normalized.outputs.working_dir }}/deploy_scripts/cloudflare/deploy_prod.sh" \
-          "${{ inputs.article_data_path }}" \
-          "${{ inputs.user_data_path }}" \
-          "${{ inputs.build_data_path }}" \
-          "${{ inputs.project_name }}" \
-          "${{ inputs.site_url }}" \
-          "${{ inputs.public_key_path }}"
+        bash "${WORKING_DIR}/deploy_scripts/cloudflare/deploy_preview.sh" \
+          "${PREVIEW_NAME}" \
+          "${ARTICLE_DATA_PATH}" \
+          "${USER_DATA_PATH}" \
+          "${BUILD_DATA_PATH}" \
+          "${PROJECT_NAME}" \
+          "${SITE_URL}" \
+          "${PUBLIC_KEY_PATH}"
 
     - name: Save build cache
       shell: bash
       working-directory: ${{ steps.normalized.outputs.working_dir }}
       run: mv ./target /tmp/fblog_system_build_cache
+
+    - id: outputs
+      name: Set outputs
+      shell: bash
+      env:
+        WORKING_DIR: ${{ steps.normalized.outputs.working_dir }}
+      run: |
+        echo "events_jsonl=${WORKING_DIR}/events.jsonl" >> "$GITHUB_OUTPUT"
+        preview_url="$(cat "${WORKING_DIR}/crates/cloudflare_workers/preview_url")"
+        echo "preview_url=${preview_url}" >> "$GITHUB_OUTPUT"

--- a/.github/ghalint.yaml
+++ b/.github/ghalint.yaml
@@ -1,0 +1,5 @@
+excludes:
+  - policy_name: action_ref_should_be_full_length_commit_sha
+    action_name: dtolnay/rust-toolchain
+  - policy_name: action_ref_should_be_full_length_commit_sha
+    action_name: docker://rhysd/actionlint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,17 +3,60 @@ name: CI
 on:
   push:
 
+env:
+  GHALINT_VERSION: v1.5.6
+
 jobs:
-  test:
-    timeout-minutes: 30
+  github-actions-lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: stable
+
+      - name: Install ghalint
+        run: go install "github.com/suzuki-shunsuke/ghalint/cmd/ghalint@${GHALINT_VERSION}"
+
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint:1.7.12 # zizmor: ignore[unpinned-images] Docker action is pinned to the requested tag.
+        with:
+          args: -color
+
+      - name: Run zizmor
+        if: ${{ !cancelled() }}
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          advanced-security: false
+          version: 1.25.2
+
+      - name: Run ghalint
+        if: ${{ !cancelled() }}
+        run: ghalint run
+        env:
+          GHALINT_LOG_COLOR: always
+          GITHUB_TOKEN: ${{ github.token }}
+
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Enable corepack
         run: corepack enable
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -21,7 +64,7 @@ jobs:
       - name: Install Node dependencies
         run: pnpm install
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@stable # zizmor: ignore[unpinned-uses] Channel refs select the requested Rust toolchain.
 
       - id: worker_build
         name: Load worker-build version
@@ -32,7 +75,7 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/registry
@@ -41,7 +84,7 @@ jobs:
           restore-keys: ${{ github.ref_name != github.event.repository.default_branch && format('{0}-cargo-', runner.os) }}
 
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             target
@@ -50,14 +93,16 @@ jobs:
 
       - id: worker_build_binary_cache
         name: Restore worker-build cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           key: fblog_system-cargo_install-worker-build-${{ steps.worker_build.outputs.version }}
           path: ~/.cargo/bin/worker-build
 
       - name: Install worker-build
         if: steps.worker_build_binary_cache.outputs.cache-hit != 'true'
-        run: cargo install --locked "worker-build@${{ steps.worker_build.outputs.version }}" --force
+        run: cargo install --locked "worker-build@${WORKER_BUILD_VERSION}" --force
+        env:
+          WORKER_BUILD_VERSION: ${{ steps.worker_build.outputs.version }}
 
       - run: cargo fetch --locked
 
@@ -73,7 +118,7 @@ jobs:
       - name: Fix certificate permissions
         run: |
           sleep 10
-          sudo chown -R $(id -u):$(id -g) test_config/caddy-data
+          sudo chown -R "$(id -u):$(id -g)" test_config/caddy-data
           sudo chmod -R a+rX test_config/caddy-data
 
       - name: Build site
@@ -93,7 +138,7 @@ jobs:
 
       - name: Upload logs as artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: e2e-test-logs
           path: logs/
@@ -101,8 +146,13 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Enable corepack
         run: corepack enable
@@ -110,7 +160,7 @@ jobs:
       - name: Start caddy
         run: docker compose -f test_config/compose.yml up -d caddy
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -118,12 +168,12 @@ jobs:
       - name: Install Node dependencies
         run: pnpm install
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@stable # zizmor: ignore[unpinned-uses] Channel refs select the requested Rust toolchain.
         with:
           components: clippy
 
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/registry
@@ -132,7 +182,7 @@ jobs:
           restore-keys: ${{ github.ref_name != github.event.repository.default_branch && format('{0}-cargo-', runner.os) }}
 
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             target
@@ -152,7 +202,7 @@ jobs:
 
       - name: Fix certificate permissions
         run: |
-          sudo chown -R $(id -u):$(id -g) test_config/caddy-data
+          sudo chown -R "$(id -u):$(id -g)" test_config/caddy-data
           sudo chmod -R a+rX test_config/caddy-data
 
       - name: cargo clippy
@@ -164,15 +214,20 @@ jobs:
 
   cloudflare_wasm_build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@stable # zizmor: ignore[unpinned-uses] Channel refs select the requested Rust toolchain.
         with:
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/registry
@@ -181,7 +236,7 @@ jobs:
           restore-keys: ${{ github.ref_name != github.event.repository.default_branch && format('{0}-cargo-', runner.os) }}
 
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             target
@@ -198,10 +253,15 @@ jobs:
 
   rustfmt:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@nightly # zizmor: ignore[unpinned-uses] Channel refs select the requested Rust toolchain.
         with:
           components: rustfmt
 
@@ -210,10 +270,15 @@ jobs:
 
   taplo:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@stable # zizmor: ignore[unpinned-uses] Channel refs select the requested Rust toolchain.
 
       - id: taplo_cli
         name: Load taplo-cli version
@@ -225,7 +290,7 @@ jobs:
 
       - id: taplo-cache
         name: Restore taplo-cli cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cargo/bin/taplo
           key: ${{ runner.os }}-taplo-cli-${{ steps.taplo_cli.outputs.version }}
@@ -233,7 +298,9 @@ jobs:
       - name: install taplo-cli
         if: steps.taplo-cache.outputs.cache-hit != 'true'
         run: |
-          cargo install --locked "taplo-cli@${{ steps.taplo_cli.outputs.version }}" --force
+          cargo install --locked "taplo-cli@${TAPLO_CLI_VERSION}" --force
+        env:
+          TAPLO_CLI_VERSION: ${{ steps.taplo_cli.outputs.version }}
 
       - name: taplo fmt
         run: ~/.cargo/bin/taplo fmt --check

--- a/.github/workflows/junie.yml
+++ b/.github/workflows/junie.yml
@@ -1,9 +1,6 @@
 name: Junie
 run-name: Junie run ${{ inputs.run_id }}
 
-permissions:
-  contents: write
-
 on:
   workflow_dispatch:
     inputs:
@@ -16,6 +13,8 @@ on:
 
 jobs:
   call-workflow-passing-data:
-    uses: jetbrains-junie/junie-workflows/.github/workflows/ej-issue.yml@main
+    permissions:
+      contents: write
+    uses: jetbrains-junie/junie-workflows/.github/workflows/ej-issue.yml@b4f71597a0a5aaa196d1191efe33f6f77517f792 # main
     with:
       workflow_params: ${{ inputs.workflow_params }}

--- a/.github/workflows/main_to_stable_pr.yml
+++ b/.github/workflows/main_to_stable_pr.yml
@@ -6,19 +6,19 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pull-requests: write
-
 concurrency:
   group: create-main-to-stable-pr
 
 jobs:
   create-pr:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Create or reuse PR from main to stable
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/sample_build_vrt_capture.yml
+++ b/.github/workflows/sample_build_vrt_capture.yml
@@ -11,16 +11,19 @@ on:
 jobs:
   capture:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       statuses: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Enable corepack
         run: corepack enable
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -31,12 +34,12 @@ jobs:
       - name: Capture sample build
         run: bash ./.github/scripts/capture_sample_build_vrt_data.sh
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sample-build-vrt-data
           path: dist
 
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           SUCCESSOR_NAME: ${{ github.event_name == 'pull_request' && 'pr_checks' || 'publish_baseline' }}
         with:

--- a/.github/workflows/sample_build_vrt_report.yml
+++ b/.github/workflows/sample_build_vrt_report.yml
@@ -1,6 +1,6 @@
 name: Sample build VRT Report
 
-on:
+on: # zizmor: ignore[dangerous-triggers] This workflow consumes artifacts from the paired capture workflow.
   workflow_run:
     workflows: ["Sample build VRT Capture"]
     types: [completed]
@@ -13,11 +13,13 @@ jobs:
   publish_baseline:
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == github.event.repository.default_branch
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       actions: read
+      contents: read
       statuses: write
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         with:
@@ -32,7 +34,7 @@ jobs:
               target_url: process.env.RUN_URL,
             });
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: sample-build-vrt-data
           path: ./actual
@@ -42,16 +44,18 @@ jobs:
       - name: Archive baseline
         run: tar -I 'zstd -19' -cf saved.tar.zst -C ./actual .
 
-      - uses: cloudflare/wrangler-action@v4
+      - uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
+        env:
+          VRT_CF_R2_BUCKET: ${{ secrets.VRT_CF_R2_BUCKET }}
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           wranglerVersion: ${{ env.VRT_WRANGLER_VERSION }}
           command: |
-            r2 object put ${{ secrets.VRT_CF_R2_BUCKET }}/visual-regression/sample-build-vrt/saved_tar_zst --file ./saved.tar.zst --remote
+            r2 object put "$VRT_CF_R2_BUCKET/visual-regression/sample-build-vrt/saved_tar_zst" --file ./saved.tar.zst --remote
 
       - if: always()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           JOB_STATUS: ${{ job.status }}
           RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -75,13 +79,15 @@ jobs:
   pr_checks:
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       actions: read
+      contents: read
       issues: write
       pull-requests: write
       statuses: write
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         with:
@@ -96,7 +102,7 @@ jobs:
               target_url: process.env.RUN_URL,
             });
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: sample-build-vrt-data
           path: ./actual
@@ -104,13 +110,15 @@ jobs:
           github-token: ${{ github.token }}
 
       - continue-on-error: true
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
+        env:
+          VRT_CF_R2_BUCKET: ${{ secrets.VRT_CF_R2_BUCKET }}
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           wranglerVersion: ${{ env.VRT_WRANGLER_VERSION }}
           command: |
-            r2 object get ${{ secrets.VRT_CF_R2_BUCKET }}/visual-regression/sample-build-vrt/saved_tar_zst --file main-saved.tar.zst --remote
+            r2 object get "$VRT_CF_R2_BUCKET/visual-regression/sample-build-vrt/saved_tar_zst" --file main-saved.tar.zst --remote
 
       - name: Unpack baseline
         run: |
@@ -145,15 +153,20 @@ jobs:
             --output-html ./regression/index.html \
             --output-json ./data/sample-build-vrt/report/report.json
 
-      - uses: cloudflare/wrangler-action@v4
+      - uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
+        env:
+          VRT_CF_PAGES_PROJECT_NAME: ${{ vars.VRT_CF_PAGES_PROJECT_NAME }}
+          VRT_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           wranglerVersion: ${{ env.VRT_WRANGLER_VERSION }}
           command: |
-            pages deploy --project-name ${{ vars.VRT_CF_PAGES_PROJECT_NAME }} --branch pr-${{ github.event.workflow_run.pull_requests[0].number }} ./regression
+            pages deploy --project-name "$VRT_CF_PAGES_PROJECT_NAME" --branch "pr-$VRT_PR_NUMBER" ./regression
 
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          VRT_CF_PAGES_PROJECT_NAME: ${{ vars.VRT_CF_PAGES_PROJECT_NAME }}
         with:
           script: |
             const fs = require("fs");
@@ -171,7 +184,7 @@ jobs:
             | Added     | ${report.added}     |
             | Deleted   | ${report.deleted}   |
 
-            [Diff Report](https://pr-${issue_number}.${{ vars.VRT_CF_PAGES_PROJECT_NAME }}.pages.dev/)
+            [Diff Report](https://pr-${issue_number}.${process.env.VRT_CF_PAGES_PROJECT_NAME}.pages.dev/)
             `;
 
             const { owner, repo } = context.repo;
@@ -209,7 +222,7 @@ jobs:
             });
 
       - if: always()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           JOB_STATUS: ${{ job.status }}
           RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/action.yml
+++ b/action.yml
@@ -46,8 +46,10 @@ runs:
   steps:
     - run: |
         mkdir -p ./.github/__tmp/fblog_system
-        cp -R "${{ github.action_path }}/.github/workflows/deploy" ./.github/__tmp/fblog_system
+        cp -R "${ACTION_PATH}/.github/actions/deploy" ./.github/__tmp/fblog_system
       shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
 
     - uses: ./.github/__tmp/fblog_system/deploy/cloudflare_workers/main
       if: ${{ inputs.target == 'cloudflare_workers' && inputs.preview_name == '' }}

--- a/renovate.json5
+++ b/renovate.json5
@@ -68,5 +68,18 @@
       versioningTemplate: "semver",
       depTypeTemplate: "binary",
     },
+
+    // ghalint release tag used by the CI workflow.
+    {
+      customType: "jsonata",
+      fileFormat: "yaml",
+      managerFilePatterns: ["/^\\.github\\/workflows\\/ci\\.yml$/"],
+      matchStrings: ['{ "depName": "ghalint", "currentValue": env.GHALINT_VERSION }'],
+      depNameTemplate: "ghalint",
+      packageNameTemplate: "suzuki-shunsuke/ghalint",
+      datasourceTemplate: "github-releases",
+      versioningTemplate: "semver",
+      depTypeTemplate: "binary",
+    },
   ],
 }


### PR DESCRIPTION
## Summary

- Add a `github-actions-lint` CI job that runs actionlint, zizmor, and ghalint.
- Pin GitHub Actions refs to full commit SHAs where supported, add job permissions/timeouts, and set checkout credential persistence to false.
- Move deploy composite actions out of `.github/workflows` so actionlint only scans workflow files.
- Add a Renovate custom manager for `GHALINT_VERSION`.

## Validation

- `actionlint -color`
- `zizmor .`
- `ghalint run`
- `ghalint run-action`
- `git diff --check`