### PR TITLE
[codex] Fix article snapshot upload path

### DIFF
--- a/deploy_scripts/cloudflare/deploy_prod.sh
+++ b/deploy_scripts/cloudflare/deploy_prod.sh
@@ -36,5 +36,5 @@ echo "=== events ==="
 cd crates/cloudflare_workers
 ./setup_resources.sh "$PROJECT_NAME" "$HOST_NAME"
 pnpm exec wrangler --cwd "$(pwd)" deploy
-pnpm exec wrangler r2 object put --remote "${PROJECT_NAME}-blog-bucket/article_snapshot_zst" -f ./article_snapshot_new.zst
+pnpm exec wrangler --cwd "$(pwd)" r2 object put --remote "${PROJECT_NAME}-blog-bucket/article_snapshot_zst" -f "$WORKING_DIR/article_snapshot_new.zst"
 CF_ACCOUNT_ID="$CLOUDFLARE_ACCOUNT_ID" CF_API_TOKEN="$CLOUDFLARE_API_TOKEN" ./send_to_queue.sh "${PROJECT_NAME}-job-queue" "$WORKING_DIR/events.jsonl"


### PR DESCRIPTION
## Summary

- Fix the production deploy script to upload `article_snapshot_new.zst` from the directory where it is generated.
- Keep the snapshot upload working after the script changes into `crates/cloudflare_workers` for Wrangler deploy commands.

## Root Cause

`update_snapshot.sh` creates `article_snapshot_new.zst` under `WORKING_DIR`, but `deploy_prod.sh` later changes directory to `crates/cloudflare_workers` and attempted to upload `./article_snapshot_new.zst`. That relative path does not exist from the new working directory, causing production deploys to fail after the Worker deploy step.

## Validation

- Ran `git diff --check`.
- Ran `bash -n deploy_scripts/cloudflare/deploy_prod.sh` with Git Bash.

Cloudflare deploy was not run locally because it requires production credentials and remote resource updates.