### PR TITLE
[codex] Fix wrangler action command variables

### DIFF
--- a/.github/workflows/sample_build_vrt_report.yml
+++ b/.github/workflows/sample_build_vrt_report.yml
@@ -45,14 +45,12 @@ jobs:
         run: tar -I 'zstd -19' -cf saved.tar.zst -C ./actual .
 
       - uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
-        env:
-          VRT_CF_R2_BUCKET: ${{ secrets.VRT_CF_R2_BUCKET }}
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           wranglerVersion: ${{ env.VRT_WRANGLER_VERSION }}
           command: |
-            r2 object put "$VRT_CF_R2_BUCKET/visual-regression/sample-build-vrt/saved_tar_zst" --file ./saved.tar.zst --remote
+            r2 object put "${{ secrets.VRT_CF_R2_BUCKET }}/visual-regression/sample-build-vrt/saved_tar_zst" --file ./saved.tar.zst --remote
 
       - if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -111,14 +109,12 @@ jobs:
 
       - continue-on-error: true
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
-        env:
-          VRT_CF_R2_BUCKET: ${{ secrets.VRT_CF_R2_BUCKET }}
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           wranglerVersion: ${{ env.VRT_WRANGLER_VERSION }}
           command: |
-            r2 object get "$VRT_CF_R2_BUCKET/visual-regression/sample-build-vrt/saved_tar_zst" --file main-saved.tar.zst --remote
+            r2 object get "${{ secrets.VRT_CF_R2_BUCKET }}/visual-regression/sample-build-vrt/saved_tar_zst" --file main-saved.tar.zst --remote
 
       - name: Unpack baseline
         run: |
@@ -154,15 +150,12 @@ jobs:
             --output-json ./data/sample-build-vrt/report/report.json
 
       - uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
-        env:
-          VRT_CF_PAGES_PROJECT_NAME: ${{ vars.VRT_CF_PAGES_PROJECT_NAME }}
-          VRT_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           wranglerVersion: ${{ env.VRT_WRANGLER_VERSION }}
           command: |
-            pages deploy --project-name "$VRT_CF_PAGES_PROJECT_NAME" --branch "pr-$VRT_PR_NUMBER" ./regression
+            pages deploy --project-name "${{ vars.VRT_CF_PAGES_PROJECT_NAME }}" --branch "pr-${{ github.event.workflow_run.pull_requests[0].number }}" ./regression
 
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:


### PR DESCRIPTION
## Summary

- Replace shell-style `$VRT_...` references inside `wrangler-action` `command` inputs with GitHub Actions expressions.
- Remove now-unneeded step-level env wiring for the affected Wrangler commands.

## Why

`cloudflare/wrangler-action` executes its `command` input without shell environment variable expansion, so values like `$VRT_CF_R2_BUCKET` are passed through literally to Wrangler. This caused R2 bucket names and Pages options to be interpreted as the literal variable names.

## Validation

- `git diff --check`
- CI lint/check results will run on this PR.