### PR TITLE
[codex] Lock pnpm installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Node dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - uses: dtolnay/rust-toolchain@stable # zizmor: ignore[unpinned-uses] Channel refs select the requested Rust toolchain.
 
@@ -166,7 +166,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Node dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - uses: dtolnay/rust-toolchain@stable # zizmor: ignore[unpinned-uses] Channel refs select the requested Rust toolchain.
         with:

--- a/deploy_scripts/build.sh
+++ b/deploy_scripts/build.sh
@@ -38,5 +38,5 @@ if [ "$MOVE_HTML_TO_RAW" = "true" ]; then
   done
 fi
 
-pnpm install
+pnpm install --frozen-lockfile --yes
 PUBLIC_KEY_FILE="$PUBLIC_KEY_PATH" SITE_URL="https://${HOST_NAME}" pnpm run build


### PR DESCRIPTION
## Summary
- Add `--frozen-lockfile` to CI `pnpm install` steps.
- Add `--frozen-lockfile --yes` to the build script install step.

## Why
This keeps Node dependency installation locked to `pnpm-lock.yaml` and makes the build script install non-interactive.

## Validation
- Confirmed all `pnpm install` occurrences in `.github` and `deploy_scripts` now use `--frozen-lockfile`.
- Checked `pnpm install --help` with pnpm 11.5.2 and confirmed `--yes` is supported.