### PR TITLE
Limit Cloudflare deploy credentials to API steps

### DIFF
--- a/deploy_scripts/cloudflare/deploy_preview.sh
+++ b/deploy_scripts/cloudflare/deploy_preview.sh
@@ -15,6 +15,10 @@ PUBLIC_KEY_PATH="$7"
 : "${CLOUDFLARE_ACCOUNT_ID:?CLOUDFLARE_ACCOUNT_ID is required}"
 : "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN is required}"
 
+CF_ACCOUNT_ID_VALUE="$CLOUDFLARE_ACCOUNT_ID"
+CF_API_TOKEN_VALUE="$CLOUDFLARE_API_TOKEN"
+unset CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN CF_ACCOUNT_ID CF_API_TOKEN
+
 HOST_NAME=$(node -e 'const i=process.argv[1]; console.log(new URL(/^https?:\/\//.test(i) ? i : `https://${i}`).hostname);' "$SITE_URL")
 
 "${SCRIPT_DIR}/../build.sh" \
@@ -36,4 +40,4 @@ echo "=== events ==="
 
 cd crates/cloudflare_workers
 ./setup_resources_for_preview.sh "$PROJECT_NAME" "$HOST_NAME"
-./upload_preview.sh "$PREVIEW_NAME"
+CLOUDFLARE_ACCOUNT_ID="$CF_ACCOUNT_ID_VALUE" CLOUDFLARE_API_TOKEN="$CF_API_TOKEN_VALUE" ./upload_preview.sh "$PREVIEW_NAME"

--- a/deploy_scripts/cloudflare/deploy_prod.sh
+++ b/deploy_scripts/cloudflare/deploy_prod.sh
@@ -14,6 +14,10 @@ PUBLIC_KEY_PATH="$6"
 : "${CLOUDFLARE_ACCOUNT_ID:?CLOUDFLARE_ACCOUNT_ID is required}"
 : "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN is required}"
 
+CF_ACCOUNT_ID_VALUE="$CLOUDFLARE_ACCOUNT_ID"
+CF_API_TOKEN_VALUE="$CLOUDFLARE_API_TOKEN"
+unset CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN CF_ACCOUNT_ID CF_API_TOKEN
+
 HOST_NAME=$(node -e 'const i=process.argv[1]; console.log(new URL(/^https?:\/\//.test(i) ? i : `https://${i}`).hostname);' "$SITE_URL")
 
 "${SCRIPT_DIR}/../build.sh" \
@@ -34,7 +38,7 @@ cat events.jsonl
 echo "=== events ==="
 
 cd crates/cloudflare_workers
-./setup_resources.sh "$PROJECT_NAME" "$HOST_NAME"
-pnpm exec wrangler --cwd "$(pwd)" deploy
-pnpm exec wrangler --cwd "$(pwd)" r2 object put --remote "${PROJECT_NAME}-blog-bucket/article_snapshot_zst" -f "$WORKING_DIR/article_snapshot_new.zst"
-CF_ACCOUNT_ID="$CLOUDFLARE_ACCOUNT_ID" CF_API_TOKEN="$CLOUDFLARE_API_TOKEN" ./send_to_queue.sh "${PROJECT_NAME}-job-queue" "$WORKING_DIR/events.jsonl"
+CLOUDFLARE_ACCOUNT_ID="$CF_ACCOUNT_ID_VALUE" CLOUDFLARE_API_TOKEN="$CF_API_TOKEN_VALUE" ./setup_resources.sh "$PROJECT_NAME" "$HOST_NAME"
+CLOUDFLARE_ACCOUNT_ID="$CF_ACCOUNT_ID_VALUE" CLOUDFLARE_API_TOKEN="$CF_API_TOKEN_VALUE" pnpm exec wrangler --cwd "$(pwd)" deploy
+CLOUDFLARE_ACCOUNT_ID="$CF_ACCOUNT_ID_VALUE" CLOUDFLARE_API_TOKEN="$CF_API_TOKEN_VALUE" pnpm exec wrangler --cwd "$(pwd)" r2 object put --remote "${PROJECT_NAME}-blog-bucket/article_snapshot_zst" -f "$WORKING_DIR/article_snapshot_new.zst"
+CF_ACCOUNT_ID="$CF_ACCOUNT_ID_VALUE" CF_API_TOKEN="$CF_API_TOKEN_VALUE" ./send_to_queue.sh "${PROJECT_NAME}-job-queue" "$WORKING_DIR/events.jsonl"


### PR DESCRIPTION
### Motivation
- PNPM `allowBuilds` plus the current deploy flow caused `pnpm install` to run while Cloudflare secrets were exported, allowing install-time lifecycle scripts to access deployment credentials. 
- The intent is to prevent secret exposure during dependency installation while preserving the deployment functionality that requires the credentials.

### Description
- Modified `deploy_scripts/cloudflare/deploy_prod.sh` to save `CLOUDFLARE_ACCOUNT_ID`/`CLOUDFLARE_API_TOKEN` into local shell variables, `unset` the exported variables before calling `build.sh`, and pass credentials inline only to Cloudflare-specific commands like `./setup_resources.sh`, `pnpm exec wrangler deploy`, `pnpm exec wrangler r2 object put`, and the queue sender. 
- Applied the same pattern to `deploy_scripts/cloudflare/deploy_preview.sh` so `build.sh` (which runs `pnpm install`) executes without inherited Cloudflare credentials, and credentials are restored only for `./upload_preview.sh` and other Cloudflare API steps. 
- This change isolates the site build/dependency install phase from Cloudflare secrets while preserving existing deploy behavior.

### Testing
- Ran shell syntax checks with `bash -n deploy_scripts/cloudflare/deploy_prod.sh deploy_scripts/cloudflare/deploy_preview.sh deploy_scripts/build.sh` which succeeded. 
- Ran `git diff --check` and basic static checks which produced no issues. 
- Executed a stubbed deploy harness that simulates `pnpm` and Cloudflare subcommands and verified that `pnpm install`/`pnpm run build` received no Cloudflare credentials while Cloudflare `wrangler`/upload/queue steps did, and this verification succeeded. 
- Attempted `pnpm test` but it was blocked by the environment because the container Node.js `v20.20.2` is incompatible with the project `pnpm@11.5.2` which requires Node.js `>=22.13`, so full `pnpm`-driven tests could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ae6ffdf8883289d7191d36936b403)