### PR TITLE
Pass Cloudflare credentials to snapshot steps

### DIFF
--- a/deploy_scripts/cloudflare/deploy_preview.sh
+++ b/deploy_scripts/cloudflare/deploy_preview.sh
@@ -31,7 +31,7 @@ HOST_NAME=$(node -e 'const i=process.argv[1]; console.log(new URL(/^https?:\/\//
 
 cd "$WORKING_DIR"
 
-./crates/cloudflare_workers/snapshot_diff_for_preview.sh "$PROJECT_NAME"
+CLOUDFLARE_ACCOUNT_ID="$CF_ACCOUNT_ID_VALUE" CLOUDFLARE_API_TOKEN="$CF_API_TOKEN_VALUE" ./crates/cloudflare_workers/snapshot_diff_for_preview.sh "$PROJECT_NAME"
 
 mv dist crates/cloudflare_workers/public
 echo "=== events ==="

--- a/deploy_scripts/cloudflare/deploy_prod.sh
+++ b/deploy_scripts/cloudflare/deploy_prod.sh
@@ -30,7 +30,7 @@ HOST_NAME=$(node -e 'const i=process.argv[1]; console.log(new URL(/^https?:\/\//
 
 cd "$WORKING_DIR"
 
-./crates/cloudflare_workers/update_snapshot.sh "$PROJECT_NAME"
+CLOUDFLARE_ACCOUNT_ID="$CF_ACCOUNT_ID_VALUE" CLOUDFLARE_API_TOKEN="$CF_API_TOKEN_VALUE" ./crates/cloudflare_workers/update_snapshot.sh "$PROJECT_NAME"
 
 mv dist crates/cloudflare_workers/public
 echo "=== events ==="


### PR DESCRIPTION
## Summary

- pass the saved Cloudflare account ID and API token to the preview snapshot diff step
- pass the same credentials to the production snapshot update step
- keep the dependency installation and build phase isolated from Cloudflare credentials

## Root cause

PR #314 unsets the Cloudflare credentials before the build, but did not restore them for the R2 snapshot download. Wrangler therefore reported that `CLOUDFLARE_API_TOKEN` was missing, and the existing fallback treated the failed download as an empty previous snapshot.

## Impact

Preview and production deployments can read the existing R2 snapshot with the required credentials, preventing unchanged articles from being incorrectly classified as new solely because the token was absent.

## Validation

- `bash -n deploy_scripts/cloudflare/deploy_preview.sh deploy_scripts/cloudflare/deploy_prod.sh`
- `git diff --check`
