### PR TITLE
Require authenticated actors for Undo

### DIFF
--- a/crates/core/src/common/verify.rs
+++ b/crates/core/src/common/verify.rs
@@ -12,8 +12,14 @@ use serde::Deserialize;
 
 #[derive(Debug)]
 pub enum VerifiedRequest<B> {
-    Verified(Request<Limited<B>>),
-    VerifiedDigest(Request<VerifyBody<Limited<B>>>),
+    Verified {
+        request: Request<Limited<B>>,
+        actor: String,
+    },
+    VerifiedDigest {
+        request: Request<VerifyBody<Limited<B>>>,
+        actor: String,
+    },
     CannotVerify(Request<Limited<B>>),
     VerifyFailed,
 }
@@ -266,9 +272,15 @@ where
         let limited = Limited::new(body, BODY_LIMIT);
         if let Some(digest) = digest_header {
             let body = VerifyBody::new(limited, digest);
-            VerifiedRequest::VerifiedDigest(Request::from_parts(parts, body))
+            VerifiedRequest::VerifiedDigest {
+                request: Request::from_parts(parts, body),
+                actor: actor_url.to_owned(),
+            }
         } else {
-            VerifiedRequest::Verified(Request::from_parts(parts, limited))
+            VerifiedRequest::Verified {
+                request: Request::from_parts(parts, limited),
+                actor: actor_url.to_owned(),
+            }
         }
     } else {
         tracing::info!("signature verification failed");

--- a/crates/core/src/process_queue.rs
+++ b/crates/core/src/process_queue.rs
@@ -39,6 +39,7 @@ where
             ty: _,
             id,
             verified_body,
+            verified_actor,
         } => {
             let body_raw = if let Some(body) = verified_body {
                 body
@@ -205,8 +206,11 @@ where
                         object,
                         content: _,
                     } => {
-                        if undo_actor != actor {
-                            tracing::info!(undo_actor, actor, "actor mismatch");
+                        if verified_actor
+                            .as_ref()
+                            .is_none_or(|verified_actor| verified_actor != &undo_actor || undo_actor != actor)
+                        {
+                            tracing::info!(?verified_actor, undo_actor, actor, "undo actor is not authorized");
                             return ProcessQueueResult::Finished;
                         }
                         let Some(slug) = object.strip_prefix(&format!("{}/articles/", state.url())).map(|s| s.trim_matches('/')) else {
@@ -221,8 +225,11 @@ where
                         return ProcessQueueResult::Finished;
                     }
                     ResponseBody::Follow { id: _, actor, object } => {
-                        if undo_actor != actor {
-                            tracing::info!(undo_actor, actor, "actor mismatch");
+                        if verified_actor
+                            .as_ref()
+                            .is_none_or(|verified_actor| verified_actor != &undo_actor || undo_actor != actor)
+                        {
+                            tracing::info!(?verified_actor, undo_actor, actor, "undo actor is not authorized");
                             return ProcessQueueResult::Finished;
                         }
                         if object != format!("{}/users/{username}", state.url()) {

--- a/crates/core/src/route/users/inbox.rs
+++ b/crates/core/src/route/users/inbox.rs
@@ -37,8 +37,8 @@ where
         Ok(r) => r,
         Err(_) => return StatusCode::BAD_REQUEST.into_response(),
     };
-    let (verified, bytes) = match verify_request(&state, request).await {
-        VerifiedRequest::VerifiedDigest(req) => {
+    let (verified_actor, bytes) = match verify_request(&state, request).await {
+        VerifiedRequest::VerifiedDigest { request: req, actor } => {
             let (bytes, digest_ok) = match req.into_body().collect_to_bytes().await {
                 Ok(res) => res,
                 Err(_) => return StatusCode::BAD_REQUEST.into_response(),
@@ -47,20 +47,20 @@ where
                 tracing::warn!("digest mismatch");
                 return StatusCode::BAD_REQUEST.into_response();
             }
-            (true, bytes)
+            (Some(actor), bytes)
         }
-        VerifiedRequest::Verified(req) => {
+        VerifiedRequest::Verified { request: req, actor } => {
             let Ok(collected) = http_body_util::BodyExt::collect(req.into_body()).await else {
                 return StatusCode::BAD_REQUEST.into_response();
             };
             let bytes = collected.to_bytes();
-            (true, bytes)
+            (Some(actor), bytes)
         }
         VerifiedRequest::CannotVerify(req) => {
             let Ok(collected) = http_body_util::BodyExt::collect(req.into_body()).await else {
                 return StatusCode::BAD_REQUEST.into_response();
             };
-            (false, collected.to_bytes())
+            (None, collected.to_bytes())
         }
         VerifiedRequest::VerifyFailed => return StatusCode::BAD_REQUEST.into_response(),
     };
@@ -74,7 +74,8 @@ where
             username,
             ty: inbox.ty,
             id: inbox.id.clone(),
-            verified_body: verified.then(|| data.clone()),
+            verified_body: verified_actor.is_some().then(|| data.clone()),
+            verified_actor,
         }
     } else {
         tracing::error!("failed to parse inbox data: {data}");

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -67,6 +67,8 @@ pub enum QueueData {
         ty: String,
         id: String,
         verified_body: Option<String>,
+        #[serde(default)]
+        verified_actor: Option<String>,
     },
     DeliveryNewArticleToAll {
         slug: String,
@@ -117,4 +119,25 @@ pub trait Queue {
 pub trait HTTPClient {
     type Error: Error + Send;
     fn request(&self, request: Request<Bytes>) -> impl Future<Output = Result<axum::http::Response<Body>, Self::Error>> + Send;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::QueueData;
+
+    #[test]
+    fn old_inbox_queue_data_defaults_to_an_unverified_actor() {
+        let data = serde_json::from_str::<QueueData>(
+            r#"{
+                "event_type": "Inbox",
+                "username": "default",
+                "ty": "Undo",
+                "id": "https://social.example/activities/undo-1",
+                "verified_body": null
+            }"#,
+        )
+        .unwrap();
+
+        assert!(matches!(data, QueueData::Inbox { verified_actor: None, .. }));
+    }
 }


### PR DESCRIPTION
## Summary

- carry the actor authenticated by the inbound HTTP Signature into inbox queue data
- require the authenticated actor, outer Undo actor, and embedded object actor to match before processing Undo Like or Undo Follow
- deserialize older queued inbox messages without `verified_actor` as unauthenticated

## Root cause

Undo processing trusted actor fields from an ActivityPub body fetched from an attacker-controlled activity ID. Although the outer and embedded actors were compared, neither was bound to the actor authenticated by the inbound HTTP Signature, allowing an unauthenticated request to remove another actor's follower or reaction state.

## Impact

Unauthenticated or actor-mismatched Undo activities no longer delete follower or reaction records. Correctly signed Undo activities from the matching actor continue to work.

## Validation

- `cargo test -p fblog_system_core --offline -j 1`
- `cargo check -p fblog_system_core -p fblog_system_in_memory_server -p fblog_system_frontend_cloudflare_workers --offline -j 1`
- `cargo clippy -p fblog_system_core --all-targets --offline -j 1 -- -D warnings`
- `rustfmt --edition 2024 --check` on the four changed Rust files

The Docker-backed full E2E suite was not run because its generated `dist` files and local Caddy certificate fixtures are not present in this worktree.