### PR TITLE
Update base64 and http dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,9 +161,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -533,7 +533,7 @@ version = "0.1.0"
 dependencies = [
  "arrayvec",
  "axum",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bitflags",
  "bytes",
  "chrono",
@@ -814,9 +814,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",


### PR DESCRIPTION
## Summary

- update `base64` from 0.23.0 to 0.23.1
- update `http` from 1.4.2 to 1.5.0
- keep `worker` pinned at 0.8.3

This splits the non-worker dependency updates out of #323 so they can be reviewed and merged independently.

## Impact

Only `Cargo.lock` changes. There are no source-code or `Cargo.toml` changes.

## Validation

- `cargo check --workspace --locked`
