### PR TITLE
Enable Renovate lock file maintenance

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,6 +5,10 @@
 
   minimumReleaseAge: "3 days",
 
+  lockFileMaintenance: {
+    enabled: true,
+  },
+
   packageRules: [
     {
       description: "Group npm package patch/minor updates into one PR.",


### PR DESCRIPTION
## Summary

Enable Renovate's top-level `lockFileMaintenance` configuration.

## Why

Weekly lock-file refreshes keep transitive dependency resolutions and package-manager metadata current even when direct dependency versions do not change. They can also remove stale lock entries and surface lock-file drift in a focused, reviewable pull request.

## Impact

Renovate can now open periodic lock-file-maintenance pull requests. This configuration-only change does not modify application runtime behavior or existing dependency grouping rules.

## Checks

- Parsed `renovate.json5` as a JavaScript/JSON5-compatible object and asserted `lockFileMaintenance.enabled === true`.
- Ran `git diff --check` successfully.
- Confirmed the commit contains only the intended `renovate.json5` change.